### PR TITLE
Conform to schema in Import()

### DIFF
--- a/constellix/resource_constellix_cname_record_pool.go
+++ b/constellix/resource_constellix_cname_record_pool.go
@@ -136,9 +136,9 @@ func resourceConstellixCnameRecordPoolImport(d *schema.ResourceData, m interface
 		inner := val.(map[string]interface{})
 		tpMap["value"] = fmt.Sprintf("%v", inner["value"])
 		tpMap["weight"], _ = strconv.Atoi(fmt.Sprintf("%v", inner["weight"]))
-		tpMap["disableFlag"] = fmt.Sprintf("%v", inner["disableFlag"])
+		tpMap["disable_flag"] = fmt.Sprintf("%v", inner["disableFlag"])
 		tpMap["policy"] = fmt.Sprintf("%v", inner["policy"])
-		tpMap["checkId"], _ = strconv.Atoi(fmt.Sprintf("%v", inner["checkId"]))
+		tpMap["check_id"], _ = strconv.Atoi(fmt.Sprintf("%v", inner["checkId"]))
 
 		mapListRR = append(mapListRR, tpMap)
 	}


### PR DESCRIPTION
The Import method on cname record pools set fields incorrectly on the
ResourceData object, causing the import to fail. Instead of using the
underscore notation defined in the ResourceSchema, camelCase is used.
Correcting this to use underscores ensures that values are
correctly imported rather than being discarded.