### PR TITLE
Example value had IP instead of FQDN

### DIFF
--- a/website/docs/r/cnamerecordpool.html.markdown
+++ b/website/docs/r/cnamerecordpool.html.markdown
@@ -17,7 +17,7 @@ resource "constellix_cname_record_pool" "firstrecord" {
   num_return             = "10"
   min_available_failover = 1
   values {
-    value        = "8.1.1.1"
+    value        = "www.example.com"
     weight       = 20
     policy       = "followsonar"
     disable_flag = false


### PR DESCRIPTION
changed 8.1.1.1 to www.example.com since CNAMEs don't point to IPs.