### PR TITLE
example resource name was incorrect

### DIFF
--- a/website/docs/r/http_check.html.markdown
+++ b/website/docs/r/http_check.html.markdown
@@ -11,7 +11,7 @@ Manages one or more HTTP check resource.
 # Example Usage #
 ```hcl
         
-resource "constellix_http_check" "first" {
+resource "constellix_http_check_record" "first" {
   name = "http check"
   host = "constellix.com"
   ip_version = "IPV4"


### PR DESCRIPTION
constellix_http_check get's rejected, constellix_http_check_record is correct