### PR TITLE
Bumped go version for go releaser to enable releases of windows/darwin arm64 builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.14
+          go-version: 1.17
       -
         name: Import GPG key
         id: import_gpg


### PR DESCRIPTION
Noticed in your github actions release workflow that it warns about go 1.14 not supporting arm64 builds well.

https://github.com/Constellix/terraform-provider-constellix/runs/3968341143?check_suite_focus=true#step:6:32

Bumped the version in your .goreleaser.yml to enable these builds, as the provider does not work on m1 macs.
This will fix issue: https://github.com/Constellix/terraform-provider-constellix/issues/40