### PR TITLE
Documentation cleanup

### DIFF
--- a/website/docs/r/a_record.html.markdown
+++ b/website/docs/r/a_record.html.markdown
@@ -59,39 +59,45 @@ resource "constellix_a_record" "firstrecord" {
 ```
 
 ## Argument Reference ##
-* `source_type` - (Required) Type of the A record. The values which can be applied are "domains" or "templates".
-* `ttl` - (Required) TTL must be in between 0 and 2147483647.
+* `source_type` - (Required) Type of the A record. The values which can be applied are `domains` or `templates`.
+* `ttl` - (Required) TTL must be in between `0` and `2147483647`.
 * `roundrobin` - (Optional) Object.
 * `roundrobin.value` - (Optional) IPv4 address.
-* `roundrobin.disable_flag` - (Optional) enable or disable the roundrobin object. Default is false. Atleast one roundrobin object should be false.
+* `roundrobin.disable_flag` - (Optional) enable or disable the roundrobin object. Default is `false`. At least one roundrobin object should be false.
 * `name` - (Optional) Name of record. Name should be unique.
-* `geo_location` - (Optional) Details of IP filter / Geo proximity to be applied. Default is null.
+* `geo_location` - (Optional) Details of IP filter / Geo proximity to be applied. Default is `null`.
 * `geo_location.geo_ip_user_region` - (Optional) For Geo proximity to be applied. geoipUserRegion should not be provided.
-* `geo_location.drop` - (Optional) drop flag. Default is false.
-* `geo_location.geo_ip_proximity` - (Optional) a valid geoipProximity id.
-* `geo_location.geo_ip_user_region` - (Optional) For Geo IP Filter to be applied. geoipUserRegion should be [1].
-* `geo_location.drop` - (Optional) drop flag. Default is false.
-* `geo_location.geo_ip_failover` - (Optional) Flag to enable/disable Failover to nearest proximity when all the host fails. Works with the record type pools. It requires Geo Proximity to be enabled at the Domain level. Default is false. 
+* `geo_location.drop` - (Optional) drop flag. Default is `false`.
+* `geo_location.geo_ip_proximity` - (Optional) A valid geoipProximity id.
+* `geo_location.geo_ip_user_region` - (Optional) For Geo IP Filter to be applied. geoipUserRegion should be `1`.
+* `geo_location.drop` - (Optional) drop flag. Default is `false`.
+* `geo_location.geo_ip_failover` - (Optional) Flag to enable/disable Failover to nearest proximity when all the host fails. Works with the record type pools. It requires Geo Proximity to be enabled at the Domain level. Default is `false`. 
 * `geo_location.geo_ip_proximity` - (Optional) for Geo IP Filter, geoipProximity must not be provided. please create an A record with "World (Default)" IP Filter first before a more specific IP Filter is applied. The "World (Default)" record would only be used if no matching Filter or Proximity records are found.
-* `record_option` - (Optional) Type of record. "roundRobin" for Standard record (Default). "failover" for Failover. "pools" for Pools. "roundRobinFailover" for Round Robin with Failover.
-* `noanswer` - (Optional) Shows if record is enabled or disabled. Default is false (Active).
-* `note` - (Optional)Record note.
-* `gtd_region` - (Optional) Shows id of GTD region in which record is to be created. 1 for World (Default). 2 for Europe. 3 for US East. 4 for US West. 5 for Asia Pacific. 6 for Oceania. note: "gtdRegion" from 2 to 6 will be applied only when GTD region is enabled on domain.
-* `type` - (Optional) Record type A.
+* `record_option` - (Optional) Type of record. "roundRobin" for Standard record (Default). `failover` for Failover. `pools` for Pools. `roundRobinFailover` for Round Robin with Failover.
+* `noanswer` - (Optional) Shows if record is enabled or disabled. Default is `false` (Active).
+* `note` - (Optional) Record note.
+* `gtd_region` - (Optional) Shows id of GTD region in which record is to be created. note: "gtdRegion" from 2 to 6 will be applied only when GTD region is enabled on domain. 
+  * `1` for World (Default). 
+  * `2` for Europe. 
+  * `3` for US East. 
+  * `4` for US West. 
+  * `5` for Asia Pacific. 
+  * `6` for Oceania.
+* `type` - (Optional) Record type `A`.
 * `contact_ids` - (Optional) Applied contact list id. Only applicable to record with type roundRobin with failover and failover.
-* `pools` - (Optional) Ids of Apool.
+* `pools` - (Optional) Ids of A pool.
 * `roundrobin_failover` - (Optional) Set.
 * `roundrobin_failover.value` - (Required for failover) IPv4 address.
-* `roundrobin_failover.disable_flag` - (Required for failover) enable or disable the recordFailover value object. Default is false (Active). Atleast one recordFailover value object should be false.
-* `roundrobin_failover.sort_order` - (Requiredfor failover) Integer value which decides in which order the rounrobinfailover should be sorted.
+* `roundrobin_failover.disable_flag` - (Required for failover) enable or disable the recordFailover value object. Default is `false` (Active). At least one recordFailover value object should be false.
+* `roundrobin_failover.sort_order` - (Required for failover) Integer value which decides in which order the rounrobinfailover should be sorted.
 * `record_failover` - (Optional) To create a record failover object pass the following attributes.
 * `record_failover_values` - (Required for failover) Set. 
 * `record_failover_values.value` - (Required for failover) IPv4 address.
 * `record_failover_values.check_id` - (Optional) Sonar check id.
 * `record_failover_values.sort_order` - (Required for failover) Integer value which decides in which order the recordfailover should be sorted.
-* `record_failover_values.disable_flag` - (Required for failover) enable or disable the recordFailover value object. Default is false (Active). Atleast one recordFailover value object should be false.
-* `record_failover_failover_type` - (Required for failover) 1 for Normal (always lowest level). 2 for Off on any Failover event. 3 for One Way (move to higher level).
-* `record_failover_disable_flag` - (Required for failover) enable or disable the recordFailover object. Default is false (Active). Atleast one recordFailover object should be false.
+* `record_failover_values.disable_flag` - (Required for failover) Enable or disable the recordFailover value object. Default is `false` (Active). At least one recordFailover value object should be false.
+* `record_failover_failover_type` - (Required for failover) `1` for Normal (always lowest level). `2` for Off on any Failover event. `3` for One Way (move to higher level).
+* `record_failover_disable_flag` - (Required for failover) enable or disable the recordFailover object. Default is `false` (Active). At least one recordFailover object should be false.
 
 ## Attributes Reference
 This resource exports the following attributes:

--- a/website/docs/r/a_record.html.markdown
+++ b/website/docs/r/a_record.html.markdown
@@ -94,7 +94,8 @@ resource "constellix_a_record" "firstrecord" {
 * `record_failover_disable_flag` - (Required for failover) enable or disable the recordFailover object. Default is false (Active). Atleast one recordFailover object should be false.
 
 ## Attributes Reference
-The only attribute that this resource exports is the `id`, which is set to the constellix calculated id of the A resource.
+This resource exports the following attributes:
+* `id` - The constellix calculated id of the A resource.
 
 ## Importing ##
 

--- a/website/docs/r/a_record_pool.html.markdown
+++ b/website/docs/r/a_record_pool.html.markdown
@@ -32,14 +32,14 @@ resource "constellix_a_record_pool" "firstrecord" {
 
 ## Argument Reference ##
 * `name` - (Required) Pool name should be unique.
-* `num_return` - (Required) minimum number of value object to return. Value must be in between 0 and 64.
-* `min_available_failover` - (Required)minimum number of Available Failover . Value must be in between 0 and 64.
+* `num_return` - (Required) Minimum number of value object to return. Value must be in between 0 and 64.
+* `min_available_failover` - (Required) Minimum number of Available Failover .Value must be in between 0 and 64.
 * `version` - (Optional) System generated version number.
 * `failed_flag` - (Optional) failed flag. Default is false.
 * `disable_flag` - (Optional) Enable or disable pool values. Default is false.
-* `values` - (Required) Object Number of IP/Hosts in a pool values cannot be less than the "Num Return" and "Min Available" values
+* `values` - (Required) Object Number of IP/Hosts in a pool values cannot be less than the "Num Return" and "Min Available" values.
 * `values.value` - (Required) IPv4 address.
-* `values.weight` - (Required) weight number to sort the priorty. Weight must be in between 1 and 1000000.
+* `values.weight` - (Required) Weight number to sort the priorty. Weight must be in between 1 and 1000000.
 * `values.disable_flag` - (Optional) Enable or disable pool values. Default is false.
 * `values.check_id` - (Optional) Sonar check id is required when you want to apply the ITO feature on a pool.
 * `values.policy` - (Required) "followsonar" for Follow sonar. "alwaysoff" for Always off. "alwayson" for Always on. "offonfailure" for Off on Failure.

--- a/website/docs/r/a_record_pool.html.markdown
+++ b/website/docs/r/a_record_pool.html.markdown
@@ -14,7 +14,7 @@ description: |-
 ```hcl
 resource "constellix_a_record_pool" "firstrecord" {
   name                   = "firstrecord"
-  num_return             = "10"
+  num_return             = 1
   min_available_failover = 1
   values {
     value        = "8.1.1.1"

--- a/website/docs/r/a_record_pool.html.markdown
+++ b/website/docs/r/a_record_pool.html.markdown
@@ -32,17 +32,17 @@ resource "constellix_a_record_pool" "firstrecord" {
 
 ## Argument Reference ##
 * `name` - (Required) Pool name should be unique.
-* `num_return` - (Required) Minimum number of value object to return. Value must be in between 0 and 64.
-* `min_available_failover` - (Required) Minimum number of Available Failover .Value must be in between 0 and 64.
+* `num_return` - (Required) Minimum number of value object to return. Value must be in between `0` and `64`.
+* `min_available_failover` - (Required) Minimum number of Available Failover .Value must be in between `0` and `64`.
 * `version` - (Optional) System generated version number.
-* `failed_flag` - (Optional) failed flag. Default is false.
-* `disable_flag` - (Optional) Enable or disable pool values. Default is false.
+* `failed_flag` - (Optional) Failed flag. Default is `false`.
+* `disable_flag` - (Optional) Enable or disable pool values. Default is `false`.
 * `values` - (Required) Object Number of IP/Hosts in a pool values cannot be less than the "Num Return" and "Min Available" values.
 * `values.value` - (Required) IPv4 address.
-* `values.weight` - (Required) Weight number to sort the priorty. Weight must be in between 1 and 1000000.
-* `values.disable_flag` - (Optional) Enable or disable pool values. Default is false.
+* `values.weight` - (Required) Weight number to sort the priorty. Weight must be in between `1` and `1000000`.
+* `values.disable_flag` - (Optional) Enable or disable pool values. Default is `false`.
 * `values.check_id` - (Optional) Sonar check id is required when you want to apply the ITO feature on a pool.
-* `values.policy` - (Required) "followsonar" for Follow sonar. "alwaysoff" for Always off. "alwayson" for Always on. "offonfailure" for Off on Failure.
+* `values.policy` - (Required) `followsonar` for Follow sonar. `alwaysoff` for Always off. `alwayson` for Always on. `offonfailure` for Off on Failure.
 * `note` - (Optional) Description.
 
 ## Attributes Reference

--- a/website/docs/r/a_record_pool.html.markdown
+++ b/website/docs/r/a_record_pool.html.markdown
@@ -46,7 +46,8 @@ resource "constellix_a_record_pool" "firstrecord" {
 * `note` - (Optional) Description.
 
 ## Attributes Reference
-The only attribute that this resource exports is the `id`, which is set to the constellix calculated id of the A record pool resource.
+This resource exports the following attributes:
+* `id` - The constellix calculated id of the A record pool resource.
 
 ## Importing ##
 

--- a/website/docs/r/aaaa_record.html.markdown
+++ b/website/docs/r/aaaa_record.html.markdown
@@ -59,39 +59,44 @@ resource "constellix_aaaa_record" "firstrecord" {
 ```
 
 ## Argument Reference ##
-* `source_type` - (Required) Type of the AAAA record. The values which can be applied are "domains" or "templates".
-* `ttl` - (Required) TTL must be in between 0 and 2147483647.
+* `source_type` - (Required) Type of the AAAA record. The values which can be applied are `domains` or `templates`.
+* `ttl` - (Required) TTL must be in between `0` and `2147483647`.
 * `roundrobin` - (Required) Object.
 * `roundrobin.value` - (Required) IPv6 address.
-* `roundrobin.disable_flag` - (Required) enable or disable the roundrobin object. Default is false. Atleast one roundrobin object should be false.
+* `roundrobin.disable_flag` - (Required) Enable or disable the roundrobin object. Default is `false`. At least one roundrobin object should be false.
 * `name` - (Optional) Name of record. Name should be unique.
 * `geo_location` - (Optional) Details of IP filter / Geo proximity to be applied. Default is null.
 * `geo_location.geo_ip_user_region` - (Optional) For Geo proximity to be applied. geoipUserRegion should not be provided.
-* `geo_location.drop` - (Optional) drop flag. Default is false.
-* `geo_location.geo_ip_proximity` - (Optional) a valid geoipProximity id.
-* `geo_location.geo_ip_user_region` - (Optional) For Geo IP Filter to be applied. geoipUserRegion should be [1].
-* `geo_location.drop` - (Optional) drop flag. Default is false.
-* `geo_location.geo_ip_failover` - (Optional) Flag to enable/disable Failover to nearest proximity when all the host fails. Works with the record type pools. It requires Geo Proximity to be enabled at the Domain level. Default is false. 
+* `geo_location.drop` - (Optional) Drop flag. Default is `false`.
+* `geo_location.geo_ip_proximity` - (Optional) A valid geoipProximity id.
+* `geo_location.geo_ip_user_region` - (Optional) For Geo IP Filter to be applied. geoipUserRegion should be `1`.
+* `geo_location.geo_ip_failover` - (Optional) Flag to enable/disable Failover to nearest proximity when all the host fails. Works with the record type pools. It requires Geo Proximity to be enabled at the Domain level. Default is `false`. 
 * `geo_location.geo_ip_proximity` - (Optional) for Geo IP Filter, geoipProximity must not be provided. please create an A record with "World (Default)" IP Filter first before a more specific IP Filter is applied. The "World (Default)" record would only be used if no matching Filter or Proximity records are found.
-* `record_option` - (Optional) Type of record. "roundRobin" for Standard record (Default). "failover" for Failover. "pools" for Pools. "roundRobinFailover" for Round Robin with Failover.
-* `noanswer` - (Optional) Shows if record is enabled or disabled. Default is false (Active).
-* `note` - (Optional)Record note.
-* `gtd_region` - (Optional) Shows id of GTD region in which record is to be created. 1 for World (Default). 2 for Europe. 3 for US East. 4 for US West. 5 for Asia Pacific. 6 for Oceania. note: "gtdRegion" from 2 to 6 will be applied only when GTD region is enabled on domain.
-* `type` - (Optional) Record type AAAA.
+* `record_option` - (Optional) Type of record. `roundRobin` for Standard record (Default). `failover` for Failover. `pools` for Pools. `roundRobinFailover` for Round Robin with Failover.
+* `noanswer` - (Optional) Shows if record is enabled or disabled. Default is `false` (Active).
+* `note` - (Optional) Record note.
+* `gtd_region` - (Optional) Shows id of GTD region in which record is to be created. note: "gtdRegion" from 2 to 6 will be applied only when GTD region is enabled on domain. 
+  * `1` for World (Default). 
+  * `2` for Europe. 
+  * `3` for US East. 
+  * `4` for US West. 
+  * `5` for Asia Pacific. 
+  * `6` for Oceania.
+* `type` - (Optional) Record type `AAAA`.
 * `contact_ids` - (Optional) Applied contact list id. Only applicable to record with type roundRobin with failover and failover.
 * `pools` - (Optional) Ids of AAAApool.
 * `roundrobin_failover` - (Optional) Set.
 * `roundrobin_failover.value` - (Required for failover) IPv6 address.
-* `roundrobin_failover.disable_flag` - (Required for failover) enable or disable the recordFailover value object. Default is false (Active). Atleast one recordFailover value object should be false.
+* `roundrobin_failover.disable_flag` - (Required for failover) Enable or disable the recordFailover value object. Default is `false` (Active). At least one recordFailover value object should be false.
 * `roundrobin_failover.sort_order` - (Required for failover) Integer value which decides in which order the roundrobinfailover should be sorted.
 * `record_failover` - (Optional) To create a record failover object pass the following attributes.
 * `record_failover_values` - (Required for failover) Set. 
 * `record_failover_values.value` - (Required for failover) IPv6 address.
 * `record_failover_values.check_id` - (Optional) Sonar check id.
 * `record_failover_values.sort_order` - (Required for failover) Integer value which decides in which order the recordfailover should be sorted
-* `record_failover_values.disable_flag` - (Required for failover) enable or disable the recordFailover value object. Default is false (Active). Atleast one recordFailover value object should be false.
-* `record_failover_failover_type` - (Required for failover) 1 for Normal (always lowest level). 2 for Off on any Failover event. 3 for One Way (move to higher level).
-* `record_failover_disable_flag` - (Required for failover) enable or disable the recordFailover object. Default is false (Active). Atleast one recordFailover object should be false.
+* `record_failover_values.disable_flag` - (Required for failover) Enable or disable the recordFailover value object. Default is `false` (Active). At least one recordFailover value object should be false.
+* `record_failover_failover_type` - (Required for failover) `1` for Normal (always lowest level). `2` for Off on any Failover event. `3` for One Way (move to higher level).
+* `record_failover_disable_flag` - (Required for failover) enable or disable the recordFailover object. Default is `false` (Active). At least one recordFailover object should be false.
 
 ## Attributes Reference
 This resource exports the following attributes:

--- a/website/docs/r/aaaa_record.html.markdown
+++ b/website/docs/r/aaaa_record.html.markdown
@@ -94,7 +94,8 @@ resource "constellix_aaaa_record" "firstrecord" {
 * `record_failover_disable_flag` - (Required for failover) enable or disable the recordFailover object. Default is false (Active). Atleast one recordFailover object should be false.
 
 ## Attributes Reference
-The only attribute that this resource exports is the `id`, which is set to the constellix calculated id of the AAAA resource.
+This resource exports the following attributes:
+* `id` - The constellix calculated id of the AAAA resource.
 
 ## Importing ##
 

--- a/website/docs/r/aaaa_record_pool.html.markdown
+++ b/website/docs/r/aaaa_record_pool.html.markdown
@@ -14,7 +14,7 @@ description: |-
 ```hcl
 resource "constellix_aaaa_record_pool" "firstrecord" {
   name                   = "firstrecord"
-  num_return             = "10"
+  num_return             = 1
   min_available_failover = 1
   values {
     value        = "0:0:0:0:0:0:0:12"
@@ -32,13 +32,13 @@ resource "constellix_aaaa_record_pool" "firstrecord" {
 
 ## Argument Reference ##
 * `name` - (Required) Pool name should be unique.
-* `num_return` - (Required) minimum number of value object to return. Value must be in between 0 and 64.
-* `min_available_failover` - (Required)minimum number of Available Failover . Value must be in between 0 and 64.
-* `failed_flag` - (Optional) failed flag. Default is false.
+* `num_return` - (Required) Minimum number of value object to return. Value must be in between 0 and 64.
+* `min_available_failover` - (Required) Minimum number of Available Failover. Value must be in between 0 and 64.
+* `failed_flag` - (Optional) Failed flag. Default is false.
 * `disable_flag` - (Optional) Enable or disable pool values. Default is false.
-* `values` - (Required) Object Number of IP/Hosts in a pool values cannot be less than the "Num Return" and "Min Available" values
+* `values` - (Required) Object Number of IP/Hosts in a pool values cannot be less than the "Num Return" and "Min Available" values.
 * `values.value` - (Required) IPv6 address.
-* `values.weight` - (Required) weight number to sort the priorty. Weight must be in between 1 and 1000000.
+* `values.weight` - (Required) Weight number to sort the priorty. Weight must be in between 1 and 1000000.
 * `values.disable_flag` - (Optional) Enable or disable pool values. Default is false.
 * `values.checkid` - (Optional) Sonar check id is required when you want to apply the ITO feature on a pool.
 * `values.policy` - (Required) "followsonar" for Follow sonar. "alwaysoff" for Always off. "alwayson" for Always on. "offonfailure" for Off on Failure.

--- a/website/docs/r/aaaa_record_pool.html.markdown
+++ b/website/docs/r/aaaa_record_pool.html.markdown
@@ -45,7 +45,8 @@ resource "constellix_aaaa_record_pool" "firstrecord" {
 * `note` - (Optional) Description.
 
 ## Attributes Reference
-The only attribute that this resource exports is the `id`, which is set to the constellix calculated id of the aaaa record pool resource.
+This resource exports the following attributes:
+* `id` - The constellix calculated id of the aaaa record pool resource.
 
 ## Importing ##
 

--- a/website/docs/r/aaaa_record_pool.html.markdown
+++ b/website/docs/r/aaaa_record_pool.html.markdown
@@ -32,14 +32,14 @@ resource "constellix_aaaa_record_pool" "firstrecord" {
 
 ## Argument Reference ##
 * `name` - (Required) Pool name should be unique.
-* `num_return` - (Required) Minimum number of value object to return. Value must be in between 0 and 64.
-* `min_available_failover` - (Required) Minimum number of Available Failover. Value must be in between 0 and 64.
-* `failed_flag` - (Optional) Failed flag. Default is false.
-* `disable_flag` - (Optional) Enable or disable pool values. Default is false.
+* `num_return` - (Required) Minimum number of value object to return. Value must be in between `0` and `64`.
+* `min_available_failover` - (Required) Minimum number of Available Failover. Value must be in between `0` and `64`.
+* `failed_flag` - (Optional) Failed flag. Default is `false`.
+* `disable_flag` - (Optional) Enable or disable pool values. Default is `false`.
 * `values` - (Required) Object Number of IP/Hosts in a pool values cannot be less than the "Num Return" and "Min Available" values.
 * `values.value` - (Required) IPv6 address.
-* `values.weight` - (Required) Weight number to sort the priorty. Weight must be in between 1 and 1000000.
-* `values.disable_flag` - (Optional) Enable or disable pool values. Default is false.
+* `values.weight` - (Required) Weight number to sort the priorty. Weight must be in between `1` and `1000000`.
+* `values.disable_flag` - (Optional) Enable or disable pool values. Default is `false`.
 * `values.checkid` - (Optional) Sonar check id is required when you want to apply the ITO feature on a pool.
 * `values.policy` - (Required) "followsonar" for Follow sonar. "alwaysoff" for Always off. "alwayson" for Always on. "offonfailure" for Off on Failure.
 * `note` - (Optional) Description.

--- a/website/docs/r/aname_record.html.markdown
+++ b/website/docs/r/aname_record.html.markdown
@@ -52,31 +52,37 @@ resource "constellix_aname_record" "aname_record1" {
 ```
 
 ## Argument Reference ##
-* `ttl` - (Required) TTL must be in between 0 and 2147483647
-* `source_type` - (Required) "domains" for Domain records and "template" for Template records
-* `geo_location` - (Optional) Details of IP filter / Geo proximity to be applied. Default is null.
-* `geo_location.drop` - (Optional) drop flag. Default is false.
+* `ttl` - (Required) TTL must be in between `0` and `2147483647`.
+* `source_type` - (Required) `domains` for Domain records and `template` for Template records.
+* `geo_location` - (Optional) Details of IP filter / Geo proximity to be applied. Default is `null`.
+* `geo_location.drop` - (Optional) Drop flag. Default is `false`.
 * `geo_location.geo_ip_proximity` - (Optional) a valid geoipProximity id.
-* `geo_location.geo_ip_user_region` - (Optional) For Geo IP Filter to be applied. geoipUserRegion should be [1].
-* `geo_location.geo_ip_failover` - (Optional) Flag to enable/disable Failover to nearest proximity when all the host fails. Works with the record type pools. It requires Geo Proximity to be enabled at the Domain level. Default is false. 
-* `roundrobin` - (Required) Set
+* `geo_location.geo_ip_user_region` - (Optional) For Geo IP Filter to be applied. geoipUserRegion should be `1`.
+* `geo_location.geo_ip_failover` - (Optional) Flag to enable/disable Failover to nearest proximity when all the host fails. Works with the record type pools. It requires Geo Proximity to be enabled at the Domain level. Default is `false`. 
+* `roundrobin` - (Required) Set.
 * `roundrobin.value` - (Required) Host name. If "Host" value does not end in a dot, your domain name will be appended to it.
-* `roundrobin.disable_flag` - (Required) Enable or Disable the roundrobin object. Default is false. Atleast one roundrobin object should be false.
+* `roundrobin.disable_flag` - (Required) Enable or Disable the roundrobin object. Default is `false`. At least one roundrobin object should be false.
 * `name` - (Optional) Name of record. Name should be unique.
-* `record_option` - (Optional) Type of record. "roundRobin" for Standard record (Default). "failover" for Failover
-* `noanswer` - (Optional) Shows if record is enabled or disabled. Default is false (Active)
+* `record_option` - (Optional) Type of record. `roundRobin` for Standard record (Default). `failover` for Failover
+* `noanswer` - (Optional) Shows if record is enabled or disabled. Default is `false` (Active)
 * `note` - (Optional) Record note
-* `gtd_region` - (Optional) Shows id of GTD region in which record is to be created, 1 for World (Default), 2 for Europe, 3 for US East, 4 for US West, 5 for Asia Pacific, 6 for Oceania, note: "gtdRegion" from 2 to 6 will be applied only when GTD region is enabled on domain.
-* `type` - (Optional) Record type ANAME
+* `gtd_region` - (Optional) Shows id of GTD region in which record is to be created. note: "gtdRegion" from 2 to 6 will be applied only when GTD region is enabled on domain. 
+  * `1` for World (Default). 
+  * `2` for Europe. 
+  * `3` for US East. 
+  * `4` for US West. 
+  * `5` for Asia Pacific. 
+  * `6` for Oceania.
+* `type` - (Optional) Record type `ANAME`.
 * `contact_ids` - (Optional) Applied contact list id. Only applicable to record with type failover.
-* `record_failover` - (Optional) Set
-* `record_failover_values` - (Required) Set
-* `record_failover_values.value` - (Required) Host name
-* `record_failover_values.check_id` - (Optional) Sonar check id
-* `record_failover_values.disable_flag` - (Required) Enable or Disable the recordfailover values object. Default is false. Atleast one object should be false.
+* `record_failover` - (Optional) Set.
+* `record_failover_values` - (Required) Set.
+* `record_failover_values.value` - (Required) Host name.
+* `record_failover_values.check_id` - (Optional) Sonar check id.
+* `record_failover_values.disable_flag` - (Required) Enable or Disable the recordfailover values object. Default is `false`. At least one object should be false.
 * `record_failover_values.sort_order` - (Required) Integer value which decides in which order recordfailover should be sorted.
-* `record_failover_failover_type` - (Optional) 1 for Normal (always lowest level), 2 for Off on any Failover event, 3 for One Way (move to higher level)
-* `record_failover_disable_flag` - (Optional) Enable or Disable the recordfailover object. Default is false. Atleast one recordfailover object should be false.
+* `record_failover_failover_type` - (Optional) `1` for Normal (always lowest level), `2` for Off on any Failover event, `3` for One Way (move to higher level).
+* `record_failover_disable_flag` - (Optional) Enable or Disable the recordfailover object. Default is `false`. At least one recordfailover object should be false.
 
 ## Attribute Reference ##
 This resource exports the following attributes:

--- a/website/docs/r/aname_record.html.markdown
+++ b/website/docs/r/aname_record.html.markdown
@@ -79,7 +79,8 @@ resource "constellix_aname_record" "aname_record1" {
 * `record_failover_disable_flag` - (Optional) Enable or Disable the recordfailover object. Default is false. Atleast one recordfailover object should be false.
 
 ## Attribute Reference ##
-The only attribute that this resource exports is the `id`, which is set to the constellix calculated id of aname resource.
+This resource exports the following attributes:
+* `id` - The constellix calculated id of aname resource.
 
 ## Importing ##
 

--- a/website/docs/r/caa_record.html.markdown
+++ b/website/docs/r/caa_record.html.markdown
@@ -39,10 +39,20 @@ resource "constellix_caa_record" "caacheck" {
 ```
 
 ## Argument Reference ##
-* `ttl` - (Required) TTL must be in between 0 and 2147483647
-* `source_type` - (Required) "domains" for Domain records and "template" for Template records
-* `roundrobin` - (Required) Set
-* `roundrobin.caa_provider_id` - (Required) 1 for [ Custom ], 2 for [ No Provider ], 3 for Comodo, 4 for Digicert, 5 for Entrust, 6 for GeoTrust, 7 for Izenpe, 8 for Lets Encrypt, 9 for Symantec, 10 for Thawte
+* `ttl` - (Required) TTL must be in between `0` and `2147483647`.
+* `source_type` - (Required) `domains` for Domain records and `template` for Template records.
+* `roundrobin` - (Required) Set.
+* `roundrobin.caa_provider_id` - (Required) 
+  * `1` for [ Custom ], 
+  * `2` for [ No Provider ], 
+  * `3` for Comodo, 
+  * `4` for Digicert, 
+  * `5` for Entrust, 
+  * `6` for GeoTrust, 
+  * `7` for Izenpe, 
+  * `8` for Lets Encrypt, 
+  * `9` for Symantec, 
+  * `10` for Thawte
 
 * `roundrobin.tag` - (Required) "issue" for Issue, "IssueWild" for IssueWild, "iodef" for iodef. Type allows you to choose how you want certificates to be issued by the CA. Each CAA record can contain only one tag-value pair. Options:
 issue: Explicitly authorizes a single certificate authority to issue a certificate (any type) for the hostname.
@@ -51,21 +61,37 @@ issuewild: Authorization to issue certificates that specify a wildcard domain. P
 
 iodef: (Incident Description Exchange Format) Specifies a means of reporting certificate issue requests or cases of certificate issue for the corresponding domain that violate the security policy of the issuer or the domain name holder.
 
-* `roundrobin.data` - (Required) "" for [ Custom ] if CAA provider Id is 1, ";" for [ No Provider ], "comodoca.com" for Comodo, "digicert.com" for Digicert, "entrust.net" for Entrust, "geotrust.com" for GeoTrust, "izenpe.com" for Izenpe, "letsencrypt.org" for Lets Encrypt, "symantec.com" for Symantec, "thawte.com" for Thawte
+* `roundrobin.data` - (Required) 
+  * `""` for [ Custom ] if CAA provider Id is 1, 
+  * `;` for [ No Provider ], 
+  * `comodoca.com` for Comodo, 
+  * `digicert.com` for Digicert, 
+  * `entrust.net` for Entrust, 
+  * `geotrust.com` for GeoTrust, 
+  * `izenpe.com` for Izenpe, 
+  * `letsencrypt.org` for Lets Encrypt, 
+  * `symantec.com` for Symantec, 
+  * `thawte.com` for Thawte.
 
-* `roundrobin.flag` - (Required) roundRobin.Issuer Critical
+* `roundrobin.flag` - (Required) roundRobin. Issuer Critical.
 
 There is currently only one flag defined, “issuer critical” at a value of 1. If a CA does not understand the flag value for an issuer critical record, then the CA will return with “no issue” for the certification.
 
-All records will have the default issuer critical value of 0, which means they are “not critical”. Issuer Critical Value should be between 0 to 255.
+All records will have the default issuer critical value of 0, which means they are “not critical”. Issuer Critical Value should be between `0` to `255`.
 
-* `roundrobin.disable_flag` - (Required) Disable flag. Default is false
+* `roundrobin.disable_flag` - (Required) Disable flag. Default is `false`.
 
 * `name` - (Optional) Name of record. Name should be unique.
-* `gtd_region` - (Optional) Shows id of GTD region in which record is to be created, 1 for World (Default), 2 for Europe, 3 for US East, 4 for US West, 5 for Asia Pacific, 6 for Oceania, note: "gtdRegion" from 2 to 6 will be applied only when GTD region is enabled on domain.
-* `noanswer` - (Optional) Shows if record is enabled or disabled. Default is false (Active)
-* `note` - (Optional) Record note
-* `type` - (Optional) Record type CAA
+* `gtd_region` - (Optional) Shows id of GTD region in which record is to be created. note: "gtdRegion" from 2 to 6 will be applied only when GTD region is enabled on domain. 
+  * `1` for World (Default). 
+  * `2` for Europe. 
+  * `3` for US East. 
+  * `4` for US West. 
+  * `5` for Asia Pacific. 
+  * `6` for Oceania.
+* `noanswer` - (Optional) Shows if record is enabled or disabled. Default is `false` (Active).
+* `note` - (Optional) Record note.
+* `type` - (Optional) Record type `CAA`.
 
 ## Attribute Reference ##
 This resource exports the following attributes:

--- a/website/docs/r/caa_record.html.markdown
+++ b/website/docs/r/caa_record.html.markdown
@@ -68,7 +68,8 @@ All records will have the default issuer critical value of 0, which means they a
 * `type` - (Optional) Record type CAA
 
 ## Attribute Reference ##
-The only attribute that this resource exports is the `id`, which is set to the constellix calculated id of caa resource.
+This resource exports the following attributes:
+* `id` - The constellix calculated id of caa resource.
 
 ## Importing ##
 

--- a/website/docs/r/cert_record.html.markdown
+++ b/website/docs/r/cert_record.html.markdown
@@ -33,19 +33,25 @@ resource "constellix_cert_record" "firstrecord" {
 ```
 
 ## Argument Reference ##
-* `source_type` - (Required) Type of the CERT record. The values which can be applied are "domains" or "templates".
-* `ttl` - (Required) TTL must be in between 0 and 2147483647.
+* `source_type` - (Required) Type of the CERT record. The values which can be applied are `domains` or `templates`.
+* `ttl` - (Required) TTL must be in between `0` and `2147483647`.
 * `name` - (Optional) Name of record. Name should be unique.
-* `noanswer` - (Optional) Shows if record is enabled or disabled. Default is false (Active).
-* `note` - (Optional)Record note.
-* `gtd_region` - (Optional) Shows id of GTD region in which record is to be created. 1 for World (Default). 2 for Europe. 3 for US East. 4 for US West. 5 for Asia Pacific. 6 for Oceania. note: "gtdRegion" from 2 to 6 will be applied only when GTD region is enabled on domain.
+* `noanswer` - (Optional) Shows if record is enabled or disabled. Default is `false` (Active).
+* `note` - (Optional) Record note.
+* `gtd_region` - (Optional) Shows id of GTD region in which record is to be created. note: "gtdRegion" from 2 to 6 will be applied only when GTD region is enabled on domain. 
+  * `1` for World (Default). 
+  * `2` for Europe. 
+  * `3` for US East. 
+  * `4` for US West. 
+  * `5` for Asia Pacific. 
+  * `6` for Oceania.
 * `roundrobin` - (Required) Object.
-* `roundrobin.certificate_type` - (Required) certificateType 0 - 65,535
-* `roundrobin.key_tag` - (Required) 0 - 65,535
-* `roundrobin.disable_flag` - (Optional) disable flag. Default is false
+* `roundrobin.certificate_type` - (Required) certificateType `0` to `65535`.
+* `roundrobin.key_tag` - (Required) Must be between `0` and `65535`.
+* `roundrobin.disable_flag` - (Optional) disable flag. Default is `false`.
 * `roundrobin.certificate` - (Required) certificate.
-* `roundrobin.algorithm` - (Required) 0-255.
-* `type` - (Optional) Record type CERT.
+* `roundrobin.algorithm` - (Required) Must be between `0` and `255`.
+* `type` - (Optional) Record type `CERT`.
 
 
 ## Attributes Reference

--- a/website/docs/r/cert_record.html.markdown
+++ b/website/docs/r/cert_record.html.markdown
@@ -49,7 +49,8 @@ resource "constellix_cert_record" "firstrecord" {
 
 
 ## Attributes Reference
-The only attribute that this resource exports is the `id`, which is set to the constellix calculated id of the CERT resource.
+This resource exports the following attributes:
+* `id` - The constellix calculated id of the CERT resource.
 
 ## Importing ##
 

--- a/website/docs/r/cname_record.html.markdown
+++ b/website/docs/r/cname_record.html.markdown
@@ -48,22 +48,28 @@ resource "constellix_cname_record" "firstrecord" {
 
 ## Argument Reference ##
 * `domain_id` - (Required) Domain ID under which CNAME record should be created.
-* `source_type` - (Required) Type of the CName record. The values which can be applied are "domains" or "templates".
-* `ttl` - (Required) TTL must be in between 0 and 2147483647.
+* `source_type` - (Required) Type of the CName record. The values which can be applied are `domains` or `templates`.
+* `ttl` - (Required) TTL must be in between `0` and `2147483647`.
 * `name` - (Optional) Name of record. Name should be unique.
 * `host` - (Required for standard CNAME) Value/"alias to" of the CNAME record.
 * `geo_location` - (Optional) Details of IP filter / Geo proximity to be applied. Default is null.
 * `geo_location.geo_ip_user_region` - (Optional) For Geo proximity to be applied. geoipUserRegion should not be provided.
-* `geo_location.drop` - (Optional) drop flag. Default is false.
-* `geo_location.geo_ip_proximity` - (Optional) a valid geoipProximity id.
-* `geo_location.geo_ip_user_region` - (Optional) For Geo IP Filter to be applied geo_ip_proximity must not be provided. Before applying a specific IP Filter you must first create a record with the same name that has IP Filter setting of "World Default". geoipUserRegion should be [1] for "World Default". Otherwise, use a valid IP Filter id number.
-* `geo_location.drop` - (Optional) drop flag. Default is false.
+* `geo_location.drop` - (Optional) Drop flag. Default is `false`.
+* `geo_location.geo_ip_proximity` - (Optional) A valid geoipProximity id.
+* `geo_location.geo_ip_user_region` - (Optional) For Geo IP Filter to be applied geo_ip_proximity must not be provided. Before applying a specific IP Filter you must first create a record with the same name that has IP Filter setting of "World Default". geoipUserRegion should be `1` for "World Default". Otherwise, use a valid IP Filter id number.
+* `geo_location.drop` - (Optional) drop flag. Default is `false`.
 * `geo_location.geo_ip_failover` - (Optional) Flag to enable/disable Failover to nearest proximity when all the host fails. Works with the record type pools and Failover. It requires Geo Proximity to be enabled at the Domain level and applied to the record you are enabeling the geo_ip_filter option on. Default is "false" mark "true" to enable. 
-* `geo_location.geo_ip_proximity` - (Optional) for Geo IP Filter, geoipProximity must not be provided. please create an A record with "World (Default)" IP Filter first before a more specific IP Filter is applied. The "World (Default)" record would only be used if no matching Filter or Proximity records are found.
+* `geo_location.geo_ip_proximity` - (Optional) For Geo IP Filter, geoipProximity must not be provided. please create an A record with "World (Default)" IP Filter first before a more specific IP Filter is applied. The "World (Default)" record would only be used if no matching Filter or Proximity records are found.
 * `record_option` - (Optional) Type of record. "roundRobin" for Standard record (Default). "failover" for Failover. "pools" for Pools. "roundRobinFailover" for Round Robin with Failover.
-* `noanswer` - (Optional) Shows if record is enabled or disabled. Default is false (Active).
-* `note` - (Optional)Record note.
-* `gtd_region` - (Optional) Shows id of GTD region in which record is to be created. 1 for World (Default). 2 for Europe. 3 for US East. 4 for US West. 5 for Asia Pacific. 6 for Oceania. note: "gtdRegion" from 2 to 6 will be applied only when GTD region is enabled on domain.
+* `noanswer` - (Optional) Shows if record is enabled or disabled. Default is `false` (Active).
+* `note` - (Optional) Record note.
+* `gtd_region` - (Optional) Shows id of GTD region in which record is to be created. note: "gtdRegion" from 2 to 6 will be applied only when GTD region is enabled on domain. 
+  * `1` for World (Default). 
+  * `2` for Europe. 
+  * `3` for US East. 
+  * `4` for US West. 
+  * `5` for Asia Pacific. 
+  * `6` for Oceania.
 * `type` - (Optional) Record type CNAME.
 * `contact_ids` - (Optional) Applied contact list id. Only applicable to record with type roundRobin with failover and failover.
 * `pools` - (Optional) Ids of CNamepool.
@@ -72,9 +78,9 @@ resource "constellix_cname_record" "firstrecord" {
 * `record_failover_values.value` - (Required for failover) Host name.
 * `record_failover_values.check_id` - (Optional) Sonar check id.
 * `record_failover_values.sort_order` - (Required for failover) Integer value which decides in which order the recordfailover should be sorted.
-* `record_failover_values.disable_flag` - (Required for failover) enable or disable the recordFailover value object. Default is false (Active). Atleast one recordFailover value object should be false.
-* `record_failover_failover_type` - (Required for failover) 1 for Normal (always lowest level). 2 for Off on any Failover event. 3 for One Way (move to higher level).
-* `record_failover_disable_flag` - (Required for failover) enable or disable the recordFailover object. Default is false (Active). Atleast one recordFailover object should be false.
+* `record_failover_values.disable_flag` - (Required for failover) Enable or disable the recordFailover value object. Default is `false` (Active). At least one recordFailover value object should be false.
+* `record_failover_failover_type` - (Required for failover) `1` for Normal (always lowest level). `2` for Off on any Failover event. `3` for One Way (move to higher level).
+* `record_failover_disable_flag` - (Required for failover) enable or disable the recordFailover object. Default is `false` (Active). At least one recordFailover object should be false.
 
 ## Attributes Reference
 This resource exports the following attributes:

--- a/website/docs/r/cname_record.html.markdown
+++ b/website/docs/r/cname_record.html.markdown
@@ -77,7 +77,8 @@ resource "constellix_cname_record" "firstrecord" {
 * `record_failover_disable_flag` - (Required for failover) enable or disable the recordFailover object. Default is false (Active). Atleast one recordFailover object should be false.
 
 ## Attributes Reference
-The only attribute that this resource exports is the `id`, which is set to the constellix calculated id of the CName resource.
+This resource exports the following attributes:
+* `id` - The constellix calculated id of the CNAME resource.
 
 ## Importing ##
 

--- a/website/docs/r/cname_record_pool.html.markdown
+++ b/website/docs/r/cname_record_pool.html.markdown
@@ -46,7 +46,8 @@ resource "constellix_cname_record_pool" "firstrecord" {
 * `note` - (Optional) Description.
 
 ## Attributes Reference
-The only attribute that this resource exports is the `id`, which is set to the constellix calculated id of the cname record pool resource.
+This resource exports the following attributes:
+* `id` - The constellix calculated id of the cname record pool resource.
 
 ## Importing ##
 

--- a/website/docs/r/cname_record_pool.html.markdown
+++ b/website/docs/r/cname_record_pool.html.markdown
@@ -14,7 +14,7 @@ description: |-
 ```hcl
 resource "constellix_cname_record_pool" "firstrecord" {
   name                   = "firstrecord"
-  num_return             = "10"
+  num_return             = 1
   min_available_failover = 1
   values {
     value        = "www.example.com"
@@ -32,14 +32,14 @@ resource "constellix_cname_record_pool" "firstrecord" {
 
 ## Argument Reference ##
 * `name` - (Required) Pool name should be unique.
-* `num_return` - (Required) minimum number of value object to return. Value must be in between 0 and 64.
-* `min_available_failover` - (Required) minimum number of Available Failover . Value must be in between 0 and 64.
+* `num_return` - (Required) Minimum number of value object to return. Value must be in between 0 and 64.
+* `min_available_failover` - (Required) Minimum number of Available Failover. Value must be in between 0 and 64.
 * `version` - (Optional) System generated version number.
-* `failed_flag` - (Optional) failed flag. Default is false.
+* `failed_flag` - (Optional) Failed flag. Default is false.
 * `disable_flag` - (Optional) Enable or disable pool values. Default is false.
 * `values` - (Required) Object Number of IP/Hosts in a pool values cannot be less than the "Num Return" and "Min Available" values
 * `values.value` - (Required) Host name. If "Host" value does not end in a dot, your domain name will be appended to it.
-* `values.weight` - (Required)weight number to sort the priorty. Weight must be in between 1 and 1000000
+* `values.weight` - (Required) Weight number to sort the priorty. Weight must be in between 1 and 1000000.
 * `values.disable_flag` - (Optional) Enable or disable pool values. Default is false.
 * `values.check_id` - (Optional) Sonar check id is required when you want to apply the ITO feature on a pool.
 * `values.policy` - (Required) "followsonar" for Follow sonar. "alwaysoff" for Always off. "alwayson" for Always on. "offonfailure" for Off on Failure.

--- a/website/docs/r/cname_record_pool.html.markdown
+++ b/website/docs/r/cname_record_pool.html.markdown
@@ -32,17 +32,21 @@ resource "constellix_cname_record_pool" "firstrecord" {
 
 ## Argument Reference ##
 * `name` - (Required) Pool name should be unique.
-* `num_return` - (Required) Minimum number of value object to return. Value must be in between 0 and 64.
-* `min_available_failover` - (Required) Minimum number of Available Failover. Value must be in between 0 and 64.
+* `num_return` - (Required) Minimum number of value object to return. Value must be in between `0` and `64`.
+* `min_available_failover` - (Required) Minimum number of Available Failover. Value must be in between `0` and `64`.
 * `version` - (Optional) System generated version number.
-* `failed_flag` - (Optional) Failed flag. Default is false.
-* `disable_flag` - (Optional) Enable or disable pool values. Default is false.
+* `failed_flag` - (Optional) Failed flag. Default is `false`.
+* `disable_flag` - (Optional) Enable or disable pool values. Default is `false`.
 * `values` - (Required) Object Number of IP/Hosts in a pool values cannot be less than the "Num Return" and "Min Available" values
 * `values.value` - (Required) Host name. If "Host" value does not end in a dot, your domain name will be appended to it.
-* `values.weight` - (Required) Weight number to sort the priorty. Weight must be in between 1 and 1000000.
-* `values.disable_flag` - (Optional) Enable or disable pool values. Default is false.
+* `values.weight` - (Required) Weight number to sort the priorty. Weight must be in between `1` and `1000000`.
+* `values.disable_flag` - (Optional) Enable or disable pool values. Default is `false`.
 * `values.check_id` - (Optional) Sonar check id is required when you want to apply the ITO feature on a pool.
-* `values.policy` - (Required) "followsonar" for Follow sonar. "alwaysoff" for Always off. "alwayson" for Always on. "offonfailure" for Off on Failure.
+* `values.policy` - (Required) 
+  * `followsonar` for Follow sonar.
+  * `alwaysoff` for Always off.
+  * `alwayson` for Always on.
+  * `offonfailure` for Off on Failure.
 * `note` - (Optional) Description.
 
 ## Attributes Reference

--- a/website/docs/r/contact_lists.html.markdown
+++ b/website/docs/r/contact_lists.html.markdown
@@ -26,7 +26,8 @@ resource "constellix_contact_lists" "contactlist1" {
 * `email_addresses` - (Required) List of email addresses
 
 ## Attribute Reference ##
-No attributes are exported
+This resource exports the following attributes:
+* `id` - The constellix calculated id of the Contact List resource.
 
 ## Importing ##
 

--- a/website/docs/r/contact_lists.html.markdown
+++ b/website/docs/r/contact_lists.html.markdown
@@ -23,7 +23,7 @@ resource "constellix_contact_lists" "contactlist1" {
 
 ## Argument Reference ##
 * `name` - (Required) Name of record. Name should be unique.
-* `email_addresses` - (Required) List of email addresses
+* `email_addresses` - (Required) List of email addresses.
 
 ## Attribute Reference ##
 This resource exports the following attributes:

--- a/website/docs/r/dns_check.html.markdown
+++ b/website/docs/r/dns_check.html.markdown
@@ -34,7 +34,8 @@ resource "constellix_dns_check" "first" {
 * `expected_response` - (Optional) Ip Address where DNS provided in the FQDN should resolved to in ideal conditions.
 
 ## Attribute Reference ##
-The only attribute that this resource exports is the `id`, which is set to the constellix calculated id of DNS check resource.
+This resource exports the following attributes:
+* `id` - The constellix calculated id of DNS check resource.
 
 
 ## Importing ##

--- a/website/docs/r/dns_check.html.markdown
+++ b/website/docs/r/dns_check.html.markdown
@@ -23,7 +23,7 @@ resource "constellix_dns_check" "first" {
 ```
 
 ## Argument Reference ##
-* `name` - (Required) name of the resource. Name should be unique.
+* `name` - (Required) Name of the resource. Name should be unique.
 * `fqdn` - (Required) A website address. It can be set only once
 * `resolver` - (Required) A website address. It can be set only once
 * `check_sites` - (Required) Site ids to check.

--- a/website/docs/r/domain.html.markdown
+++ b/website/docs/r/domain.html.markdown
@@ -43,7 +43,9 @@ resource "constellix_domain" "domain1" {
 * `soa.negcache` - (Optional) The amount of time a record not found is cached. Recommended values can vary, between 180 and 172800 (3 min – 2 days). 
 
 ## Attribute Reference ##
-* `soa.serial` - (Optional) The starting serial number for the version of the zone. If the SOA record is applied to a domain that is already created (and thus already has a starting serial number), the existing serial number will be incremented by one. e.g 2015010196
+This resource exports the following attributes:
+* `id` - The constellix calculated id of the domain resource.
+* `soa.serial` - The starting serial number for the version of the zone. If the SOA record is applied to a domain that is already created (and thus already has a starting serial number), the existing serial number will be incremented by one. e.g 2015010196
 
 ## Importing ##
 

--- a/website/docs/r/domain.html.markdown
+++ b/website/docs/r/domain.html.markdown
@@ -27,20 +27,20 @@ resource "constellix_domain" "domain1" {
 ## Argument Reference ##
 
 * `name` - (Required) Name of the domain.
-* `has_gtd_regions` - (Optional) GTD Region status of the domain. The Default value is false.
-* `has_geoip` - (Optional) GTD Region status of the domain. The Default value is false.
+* `has_gtd_regions` - (Optional) GTD Region status of the domain. The Default value is `false`.
+* `has_geoip` - (Optional) GTD Region status of the domain. The Default value is `false`.
 * `vanity_nameserver` - (Optional) vanity nameserver of domain.
-* `nameserver_group` - (Optional) Shows the nameserver group of domain. The Default nameserverGroup is 1.
+* `nameserver_group` - (Optional) Shows the nameserver group of domain. The Default nameserverGroup is `1`.
 * `note` - (Optional) Notes while creating the domain. The maximum length will be 1000 characters.
 * `tags` - (Optional) Id of tags applied on domain. The default value is empty.
-* `soa` - (Optional) Object
+* `soa` - (Optional) Object.
 * `soa.primary_nameserver` - (Optional) The Primary Nameserver is of SOA. 
 * `soa.email` - (Optional) An Email Address specifies the mailbox of the person responsible for this zone. 
 * `soa.ttl` - (Optional) The number of seconds that this SOA record will be cached in other resolving name servers. 
 * `soa.refresh` - (Optional) The time interval (in seconds) before the zone should be refreshed. The recommended value – 86400 (24 Hours). 
 * `soa.retry` - (Optional) The time interval (in seconds) before a failed refresh should be retried. Recommended value – 7200 (2 Hours). 
 * `soa.expire` - (Optional) The time internal (in seconds) that specifies the upper limit on the time internally that can elapse before the zone is no longer authoritative. This is when the secondary name servers will expire if they are unable to refresh. Recommended value – up to 1209600
-* `soa.negcache` - (Optional) The amount of time a record not found is cached. Recommended values can vary, between 180 and 172800 (3 min – 2 days). 
+* `soa.negcache` - (Optional) The amount of time a record not found is cached. Recommended values can vary, between `180` and `172800` (3 min – 2 days). 
 
 ## Attribute Reference ##
 This resource exports the following attributes:

--- a/website/docs/r/geo_filter.html.markdown
+++ b/website/docs/r/geo_filter.html.markdown
@@ -37,7 +37,8 @@ resource "constellix_geo_filter" "ipfilter1" {
 * `filter_rules_limit` - (Optional) Default is 100. For more than 100 rules, parameter should be set explicitly for ADD and Update API calls. Value should be in mulitple of 100 like 200, 300 ...upto the quota limit assigned to the account. Check quota details for IP Filter Rule Limit.
 
 ## Attributes Reference
-No attributes are exported.
+This resource exports the following attributes:
+* `id` - The constellix calculated id of the Geo Filter.
 
 ## Importing ##
 

--- a/website/docs/r/geo_filter.html.markdown
+++ b/website/docs/r/geo_filter.html.markdown
@@ -29,12 +29,12 @@ resource "constellix_geo_filter" "ipfilter1" {
 ## Argument Reference ##
 * `name` - (Required) Geo Filter name should be unique.
 * `geoip_continents` - (Optional) Two digit Continents Code.
-* `geoip_countries` - (Optional)Two digit Countries Code.
+* `geoip_countries` - (Optional) Two digit Countries Code.
 * `geoip_regions` - (Optional) Two digit country code followed by "/" followed by two digit region code. 
-* `asn` - (Optional) Autonomous System Number (ASN). ASN code should be a number between 0 and 4294967295.
+* `asn` - (Optional) Autonomous System Number (ASN). ASN code should be a number between `0` and `4294967295`.
 * `ipv4` - (Optional) IPV4 Address.
 * `ipv6` - (Optional) IPV6 Address.
-* `filter_rules_limit` - (Optional) Default is 100. For more than 100 rules, parameter should be set explicitly for ADD and Update API calls. Value should be in mulitple of 100 like 200, 300 ...upto the quota limit assigned to the account. Check quota details for IP Filter Rule Limit.
+* `filter_rules_limit` - (Optional) Default is `100`. For more than 100 rules, parameter should be set explicitly for ADD and Update API calls. Value should be in mulitple of 100 like 200, 300 ...upto the quota limit assigned to the account. Check quota details for IP Filter Rule Limit.
 
 ## Attributes Reference
 This resource exports the following attributes:

--- a/website/docs/r/geo_proximity.html.markdown
+++ b/website/docs/r/geo_proximity.html.markdown
@@ -26,11 +26,11 @@ resource "constellix_geo_proximity" "firstgeoproximity" {
 
 ## Argument Reference ##
 * `name` - (Required) Geo Proximity name should be unique.
-* `country` - (Optional) Country code. Default is null.
-* `region` - (Optional)Region or state or province code. Default is null.
+* `country` - (Optional) Country code. Default is `null`.
+* `region` - (Optional) Region or state or province code. Default is `null`.
 * `latitude` - (Optional) Latitude value.
 * `longitude` - (Optional) Longitude value.
-* `city` - (Optional)City code. Default is null.
+* `city` - (Optional) City code. Default is `null`.
 
 ## Attributes Reference
 This resource exports the following attributes:

--- a/website/docs/r/geo_proximity.html.markdown
+++ b/website/docs/r/geo_proximity.html.markdown
@@ -33,7 +33,8 @@ resource "constellix_geo_proximity" "firstgeoproximity" {
 * `city` - (Optional)City code. Default is null.
 
 ## Attributes Reference
-No attributes are exported.
+This resource exports the following attributes:
+* `id` - The constellix calculated id of the Geo Proximity resource.
 
 ## Importing ##
 

--- a/website/docs/r/hinfo_record.html.markdown
+++ b/website/docs/r/hinfo_record.html.markdown
@@ -48,7 +48,8 @@ resource "constellix_hinfo_record" "hinfo1" {
 * `type` - (Optional) Record type HINFO
 
 ## Attribute Reference ##
-The only attribute that this resource exports is the `id`, which is set to the constellix calculated id of hinfo resource.
+This resource exports the following attributes:
+* `id` - The constellix calculated id of hinfo resource.
 
 ## Importing ##
 

--- a/website/docs/r/hinfo_record.html.markdown
+++ b/website/docs/r/hinfo_record.html.markdown
@@ -35,17 +35,23 @@ resource "constellix_hinfo_record" "hinfo1" {
 ```
 
 ## Argument Reference ##
-* `ttl` - (Required) TTL must be in between 0 and 2147483647
-* `source_type` - (Required) "domains" for Domain records and "template" for Template records
-* `roundrobin` - (Required) Set
-* `roundrobin.cpu` - (Required) A description of basic system hardware
-* `roundrobin.disable_flag` - (Optional) Enable or Disable the roundrobin object. Default is false. Atleast one roundrobin object should be false.
-* `roundrobin.os` - (Required) A description of the operating system and version
+* `ttl` - (Required) TTL must be in between `0` and `2147483647`.
+* `source_type` - (Required) `domains` for Domain records and `template` for Template records.
+* `roundrobin` - (Required) Set.
+* `roundrobin.cpu` - (Required) A description of basic system hardware.
+* `roundrobin.disable_flag` - (Optional) Enable or Disable the roundrobin object. Default is `false`. At least one roundrobin object should be false.
+* `roundrobin.os` - (Required) A description of the operating system and version.
 * `name` - (Optional) Name of record. Name should be unique.
-* `noanswer` - (Optional) Shows if record is enabled or disabled. Default is false (Active)
-* `note` - (Optional) Record note
-* `gtd_region` - (Optional) Shows id of GTD region in which record is to be created, 1 for World (Default), 2 for Europe, 3 for US East, 4 for US West, 5 for Asia Pacific, 6 for Oceania, note: "gtdRegion" from 2 to 6 will be applied only when GTD region is enabled on domain.
-* `type` - (Optional) Record type HINFO
+* `noanswer` - (Optional) Shows if record is enabled or disabled. Default is `false` (Active)
+* `note` - (Optional) Record note.
+* `gtd_region` - (Optional) Shows id of GTD region in which record is to be created. note: "gtdRegion" from 2 to 6 will be applied only when GTD region is enabled on domain. 
+  * `1` for World (Default). 
+  * `2` for Europe. 
+  * `3` for US East. 
+  * `4` for US West. 
+  * `5` for Asia Pacific. 
+  * `6` for Oceania.
+* `type` - (Optional) Record type `HINFO`.
 
 ## Attribute Reference ##
 This resource exports the following attributes:

--- a/website/docs/r/http_check.html.markdown
+++ b/website/docs/r/http_check.html.markdown
@@ -24,7 +24,7 @@ resource "constellix_http_check" "first" {
 ```
 
 ## Argument Reference ##
-* `name` - (Required) name of the resource. Name should be unique.
+* `name` - (Required) Name of the resource. Name should be unique.
 * `host` - (Required) Host for the resource, for example "constellix.com". It can be set only once.
 * `ip_version` - (Required) Specifies the version of IP. It can be set only once.
 * `port` - (Required) Specifies the port number.

--- a/website/docs/r/http_check.html.markdown
+++ b/website/docs/r/http_check.html.markdown
@@ -40,7 +40,8 @@ resource "constellix_http_check" "first" {
 * `expected_status_code` - (Optional) Expected HTTP status code for this check.
 
 ## Attribute Reference ##
-The only attribute that this resource exports is the `id`, which is set to the constellix calculated id of HTTP check resource.
+This resource exports the following attributes:
+* `id` - The constellix calculated id of HTTP check resource.
 
 ## Importing ##
 

--- a/website/docs/r/http_redirection_record.html.markdown
+++ b/website/docs/r/http_redirection_record.html.markdown
@@ -45,7 +45,8 @@ resource "constellix_http_redirection_record" "http1" {
 * `type` - (Optional) Record type HTTP Redirection
 
 ## Attribute Reference ##
-The only attribute that this resource exports is the `id`, which is set to the constellix calculated id of httpredirection resource.
+This resource exports the following attributes:
+* `id` - The constellix calculated id of httpredirection resource.
 
 ## Importing ##
 

--- a/website/docs/r/http_redirection_record.html.markdown
+++ b/website/docs/r/http_redirection_record.html.markdown
@@ -31,18 +31,24 @@ resource "constellix_http_redirection_record" "http1" {
 ```
 
 ## Argument Reference ##
-* `ttl` - (Required) TTL must be in between 0 and 2147483647
-* `url` - (Required) URL link to redirect
-* `redirect_type_id` - (Required) 1 for Standard - 302, 2 for Hidden Frame Masked and 3 for Standard - 301. 
-* `source_type` - (Required) "domains" for Domain records and "template" for Template records
+* `ttl` - (Required) TTL must be in between `0` and `2147483647`.
+* `url` - (Required) URL link to redirect.
+* `redirect_type_id` - (Required) `1` for Standard - 302, `2` for Hidden Frame Masked and `3` for Standard - 301. 
+* `source_type` - (Required) `domains` for Domain records and `template` for Template records.
 * `name` - (Optional) Name of record. Name should be unique.
-* `noanswer` - (Optional) Shows if record is enabled or disabled. Default is false (Active)
-* `note` - (Optional) Record note
-* `hardlink_flag` - (Optional) Hardlink flag. Default is false
-* `description` - (Optional) Description
-* `title` - (Optional) Title of redirection
-* `gtd_region` - (Optional) Shows id of GTD region in which record is to be created, 1 for World (Default), 2 for Europe, 3 for US East, 4 for US West, 5 for Asia Pacific, 6 for Oceania, note: "gtdRegion" from 2 to 6 will be applied only when GTD region is enabled on domain.
-* `type` - (Optional) Record type HTTP Redirection
+* `noanswer` - (Optional) Shows if record is enabled or disabled. Default is `false` (Active).
+* `note` - (Optional) Record note.
+* `hardlink_flag` - (Optional) Hardlink flag. Default is `false`
+* `description` - (Optional) Description.
+* `title` - (Optional) Title of redirection.
+* `gtd_region` - (Optional) Shows id of GTD region in which record is to be created. note: "gtdRegion" from 2 to 6 will be applied only when GTD region is enabled on domain. 
+  * `1` for World (Default). 
+  * `2` for Europe. 
+  * `3` for US East. 
+  * `4` for US West. 
+  * `5` for Asia Pacific. 
+  * `6` for Oceania.
+* `type` - (Optional) Record type `HTTPRedirection`.
 
 ## Attribute Reference ##
 This resource exports the following attributes:

--- a/website/docs/r/mx_record.html.markdown
+++ b/website/docs/r/mx_record.html.markdown
@@ -35,17 +35,23 @@ resource "constellix_mx_record" "mx1" {
 ```
 
 ## Argument Reference ##
-* `ttl` - (Required) TTL must be in between 0 and 2147483647
-* `source_type` - (Required) "domains" for Domain records and "template" for Template records
-* `roundrobin` - (Required) Set
+* `ttl` - (Required) TTL must be in between `0` and `2147483647`.
+* `source_type` - (Required) `domains` for Domain records and `template` for Template records.
+* `roundrobin` - (Required) Set.
 * `roundrobin.value` - (Required) The mail server that will accept mail for the host that is specified in the name field. Your domain name is automatically appended to your value if it does not end it a dot.
-* `roundrobin.level` - (Required) Level must be in between 0 and 65535. The MX level determines the order (by priority) that remote mail servers will attempt to deliver email. The mail server with the lowest MX level will be the first priority.
-* `roundrobin.disable_flag` - (Optional) Enable or Disable the roundrobin object. Default is false. Atleast one roundrobin object should be false.
+* `roundrobin.level` - (Required) Level must be in between `0` and `65535`. The MX level determines the order (by priority) that remote mail servers will attempt to deliver email. The mail server with the lowest MX level will be the first priority.
+* `roundrobin.disable_flag` - (Optional) Enable or Disable the roundrobin object. Default is `false`. At least one roundrobin object should be false.
 * `name` - (Optional) Name of record. Name should be unique.
-* `noanswer` - (Optional) Shows if record is enabled or disabled. Default is false (Active)
-* `note` - (Optional) Record note
-* `gtd_region` - (Optional) Shows id of GTD region in which record is to be created, 1 for World (Default), 2 for Europe, 3 for US East, 4 for US West, 5 for Asia Pacific, 6 for Oceania, note: "gtdRegion" from 2 to 6 will be applied only when GTD region is enabled on domain.
-* `type` - (Optional) Record type MX
+* `noanswer` - (Optional) Shows if record is enabled or disabled. Default is `false` (Active).
+* `note` - (Optional) Record note.
+* `gtd_region` - (Optional) Shows id of GTD region in which record is to be created. note: "gtdRegion" from 2 to 6 will be applied only when GTD region is enabled on domain. 
+  * `1` for World (Default). 
+  * `2` for Europe. 
+  * `3` for US East. 
+  * `4` for US West. 
+  * `5` for Asia Pacific. 
+  * `6` for Oceania.
+* `type` - (Optional) Record type `MX`.
 
 ## Attribute Reference ##
 This resource exports the following attributes:

--- a/website/docs/r/mx_record.html.markdown
+++ b/website/docs/r/mx_record.html.markdown
@@ -48,7 +48,8 @@ resource "constellix_mx_record" "mx1" {
 * `type` - (Optional) Record type MX
 
 ## Attribute Reference ##
-The only attribute that this resource exports is the `id`, which is set to the constellix calculated id of mx resource.
+This resource exports the following attributes:
+* `id` - The constellix calculated id of mx resource.
 
 ## Importing ##
 

--- a/website/docs/r/naptr_record.html.markdown
+++ b/website/docs/r/naptr_record.html.markdown
@@ -36,26 +36,32 @@ resource "constellix_naptr_record" "firstrecord" {
 ```
 
 ## Argument Reference ##
-* `source_type` - (Required) Type of the Naptr record. The values which can be applied are "domains" or "templates".
-* `ttl` - (Required) TTL must be in between 0 and 2147483647.
+* `source_type` - (Required) Type of the Naptr record. The values which can be applied are `domains` or `templates`.
+* `ttl` - (Required) TTL must be in between `0` and `2147483647`.
 * `name` - (Optional) Name of record. Name should be unique.
-* `noanswer` - (Optional) Shows if record is enabled or disabled. Default is false (Active).
-* `note` - (Optional)Record note.
-* `gtd_region` - (Optional) Shows id of GTD region in which record is to be created. 1 for World (Default). 2 for Europe. 3 for US East. 4 for US West. 5 for Asia Pacific. 6 for Oceania. note: "gtdRegion" from 2 to 6 will be applied only when GTD region is enabled on domain.
-* `type` - (Optional) Record type Naptr.
+* `noanswer` - (Optional) Shows if record is enabled or disabled. Default is `false` (Active).
+* `note` - (Optional) Record note.
+* `gtd_region` - (Optional) Shows id of GTD region in which record is to be created. note: "gtdRegion" from 2 to 6 will be applied only when GTD region is enabled on domain. 
+  * `1` for World (Default). 
+  * `2` for Europe. 
+  * `3` for US East. 
+  * `4` for US West. 
+  * `5` for Asia Pacific. 
+  * `6` for Oceania.
+* `type` - (Optional) Record type `NAPTR`.
 * `roundrobin` - (Required) Set.
 * `roundrobin.order` - (Required) A 16-bit value ranging from 0 to 63535, the lowest number having the highest order. For example, an order of 10 is of more importance (has a higher order value) than an order of 50.
 * `roundrobin.preference` - (Required) Preference is used only when two NAPTR records with the same name also have the same order and is used to indicate preference (all other things being equal). A 16-bit value ranging from 0 to 63535, the lowest number having the highest order.
 * `roundrobin.flags` - (Required) A Flag is a single character from the set A-Z and 0-9, defined to be application specific, such that each application may define a specific use of the flag or which flags are valid. The flag is enclosed in quotes (“”). Currently defined values are: 
-U – a terminal condition – the result of the regexp is a valid URI.
-S – a terminal condition – the replace field contains the FQDN of an SRV record.
-A – a terminal condition – the replace field contains the FQDN of an A or AAAA record.
-P – a non-terminal condition – the protocol/services part of the params field determines the application specific behavior and subsequent processing is external to the record.
-“” (empty string) – a non-terminal condition to indicate that regexp is empty and the replace field contains the FQDN of a further NAPTR record.
+  * `U` – A terminal condition – the result of the regexp is a valid URI.
+  * `S` – A terminal condition – the replace field contains the FQDN of an SRV record.
+  * `A` – A terminal condition – the replace field contains the FQDN of an A or AAAA record.
+  * `P` – A non-terminal condition – the protocol/services part of the params field determines the application specific behavior and subsequent processing is external to the record.
+`“”` (empty string) – a non-terminal condition to indicate that regexp is empty and the replace field contains the FQDN of a further NAPTR record.
 * `roundrobin.service` - (Required) Defines the application specific service parameters. The generic format is: protocol+rs. Where “protocol” defines the protocol used by the application and “rs” is the resolution service. There may be 0 or more resolution services each separated by +.
 * `roundrobin.regular_expression` - (Required) A 16-bit value ranging from 0 to 63535, the lowest number having the highest order. For example, an order of 10 is of more importance (has a higher order value) than an order of 50.
 * `roundrobin.replacement` - (Required) Preference is used only when two NAPTR records with the same name also have the same order and is used to indicate preference (all other things being equal).
-* `roundrobin.disable_flag` - (Required) disable flag. Default is false
+* `roundrobin.disable_flag` - (Required) disable flag. Default is `false`.
 
 ## Attributes Reference
 This resource exports the following attributes:

--- a/website/docs/r/naptr_record.html.markdown
+++ b/website/docs/r/naptr_record.html.markdown
@@ -58,7 +58,8 @@ P – a non-terminal condition – the protocol/services part of the params fiel
 * `roundrobin.disable_flag` - (Required) disable flag. Default is false
 
 ## Attributes Reference
-The only attribute that this resource exports is the `id`, which is set to the constellix calculated id of the NAPTR resource.
+This resource exports the following attributes:
+* `id` - The constellix calculated id of the NAPTR resource.
 
 ## Importing ##
 

--- a/website/docs/r/ns_record.html.markdown
+++ b/website/docs/r/ns_record.html.markdown
@@ -45,7 +45,8 @@ resource "constellix_ns_record" "firstrecord" {
 * `roundrobin.disable_flag` - (Required) disable flag. Default is false
 
 ## Attributes Reference
-The only attribute that this resource exports is the `id`, which is set to the constellix calculated id of the NS resource.
+This resource exports the following attributes:
+* `id` - The constellix calculated id of the NS resource.
 
 ## Importing ##
 

--- a/website/docs/r/ns_record.html.markdown
+++ b/website/docs/r/ns_record.html.markdown
@@ -32,17 +32,23 @@ resource "constellix_ns_record" "firstrecord" {
 ```
 
 ## Argument Reference ##
-* `domain_id` - (Required) Record id of NS record
-* `source_type` - (Required) Type of the NS record. The values which can be applied are "domains" or "templates".
-* `ttl` - (Required) TTL must be in between 0 and 2147483647.
+* `domain_id` - (Required) Record id of NS record.
+* `source_type` - (Required) Type of the NS record. The values which can be applied are `domains` or `templates`.
+* `ttl` - (Required) TTL must be in between `0` and `2147483647`.
 * `name` - (Optional) Name of record. Name should be unique.
-* `noanswer` - (Optional) Shows if record is enabled or disabled. Default is false (Active).
+* `noanswer` - (Optional) Shows if record is enabled or disabled. Default is `false` (Active).
 * `note` - (Optional)Record note.
-* `gtd_region` - (Optional) Shows id of GTD region in which record is to be created. 1 for World (Default). 2 for Europe. 3 for US East. 4 for US West. 5 for Asia Pacific. 6 for Oceania. note: "gtdRegion" from 2 to 6 will be applied only when GTD region is enabled on domain.
-* `type` - (Optional) Record type NS.
+* `gtd_region` - (Optional) Shows id of GTD region in which record is to be created. note: "gtdRegion" from 2 to 6 will be applied only when GTD region is enabled on domain. 
+  * `1` for World (Default). 
+  * `2` for Europe. 
+  * `3` for US East. 
+  * `4` for US West. 
+  * `5` for Asia Pacific. 
+  * `6` for Oceania.
+* `type` - (Optional) Record type `NS`.
 * `roundrobin` - (Required) Set.
 * `roundrobin.value` - (Required) This will be the host name for the name server, for example ns0.nameserver.com. It is important to note, the domain name is automatically appended to the end of this field unless it ends with a dot (.).
-* `roundrobin.disable_flag` - (Required) disable flag. Default is false
+* `roundrobin.disable_flag` - (Required) disable flag. Default is `false`.
 
 ## Attributes Reference
 This resource exports the following attributes:

--- a/website/docs/r/ptr_record.html.markdown
+++ b/website/docs/r/ptr_record.html.markdown
@@ -43,7 +43,8 @@ resource "constellix_ptr_record" "ptr1" {
 * `roundrobin.disable_flag` - (Optional) enable or disable the roundrobin object. Default is false. Atleast one roundrobin object should be false.
 
 ## Attributes Reference
-The only attribute that this resource exports is the `id`, which is set to the constellix calculated id of the PTR resource.
+This resource exports the following attributes:
+* `id` - The constellix calculated id of the PTR resource.
 
 ## Importing ##
 

--- a/website/docs/r/ptr_record.html.markdown
+++ b/website/docs/r/ptr_record.html.markdown
@@ -30,17 +30,23 @@ resource "constellix_ptr_record" "ptr1" {
 ```
 
 ## Argument Reference ##
-* `domain_id` - (Required) Record id of PTR record
-* `source_type` - (Required) Type of the PTR record. The values which can be applied are "domains" or "templates".
+* `domain_id` - (Required) Record id of PTR record.
+* `source_type` - (Required) Type of the PTR record. The values which can be applied are `domains` or `templates`.
 * `name` - (Optional) Name of record. Name should be unique.
-* `ttl` - (Required) TTL must be in between 0 and 2147483647.
-* `noanswer` - (Optional) Shows if record is enabled or disabled. Default is false (Active).
+* `ttl` - (Required) TTL must be in between `0` and `2147483647`.
+* `noanswer` - (Optional) Shows if record is enabled or disabled. Default is `false` (Active).
 * `note` - (Optional)Record note.
-* `gtd_region` - (Optional) Shows id of GTD region in which record is to be created. 1 for World (Default). 2 for Europe. 3 for US East. 4 for US West. 5 for Asia Pacific. 6 for Oceania. note: "gtdRegion" from 2 to 6 will be applied only when GTD region is enabled on domain.
-* `type` - (Optional) Record type A.
+* `gtd_region` - (Optional) Shows id of GTD region in which record is to be created. note: "gtdRegion" from 2 to 6 will be applied only when GTD region is enabled on domain. 
+  * `1` for World (Default). 
+  * `2` for Europe. 
+  * `3` for US East. 
+  * `4` for US West. 
+  * `5` for Asia Pacific. 
+  * `6` for Oceania.
+* `type` - (Optional) Record type `PTR`.
 * `roundrobin` - (Required) Object.
 * `roundrobin.value` - (Required) This will be the host name of the computer or server the IP resolves to, for example mail.example.com. It is important to note, the domain name is automatically appended to the end of this field unless it ends with a dot (.).
-* `roundrobin.disable_flag` - (Optional) enable or disable the roundrobin object. Default is false. Atleast one roundrobin object should be false.
+* `roundrobin.disable_flag` - (Optional) enable or disable the roundrobin object. Default is `false`. At least one roundrobin object should be false.
 
 ## Attributes Reference
 This resource exports the following attributes:

--- a/website/docs/r/rp_record.html.markdown
+++ b/website/docs/r/rp_record.html.markdown
@@ -51,7 +51,8 @@ resource "constellix_rp_record" "rp1" {
 * `type` - (Optional) Record type RP
 
 ## Attribute Reference ##
-The only attribute that this resource exports is the `id`, which is set to the constellix calculated id of rp resource.
+This resource exports the following attributes:
+* `id` - The constellix calculated id of rp resource.
 
 ## Importing ##
 

--- a/website/docs/r/rp_record.html.markdown
+++ b/website/docs/r/rp_record.html.markdown
@@ -37,18 +37,24 @@ resource "constellix_rp_record" "rp1" {
 ```
 
 ## Argument Reference ##
-* `domain_id` - (Required) Record id of RP record
-* `ttl` - (Required) TTL must be in between 0 and 2147483647
-* `source_type` - (Required) "domains" for Domain records and "template" for Template records
-* `roundrobin` - (Required) Set
-* `roundrobin.mailbox` - (Required) A mailbox for the responsible person of the domain
-* `roundrobin.txt` - (Required) A hostname for the responsible person of the domain
-* `roundrobin.disable_flag` - (Optional) Enable or Disable the roundrobin object. Default is false. Atleast one roundrobin object should be false.
+* `domain_id` - (Required) Record id of RP record.
+* `ttl` - (Required) TTL must be in between `0` and `2147483647`.
+* `source_type` - (Required) `domains` for Domain records and `template` for Template records.
+* `roundrobin` - (Required) Set.
+* `roundrobin.mailbox` - (Required) A mailbox for the responsible person of the domain.
+* `roundrobin.txt` - (Required) A hostname for the responsible person of the domain.
+* `roundrobin.disable_flag` - (Optional) Enable or Disable the roundrobin object. Default is `false`. At least one roundrobin object should be false.
 * `name` - (Optional) Name of record. Name should be unique.
-* `noanswer` - (Optional) Shows if record is enabled or disabled. Default is false (Active)
-* `note` - (Optional) Record note
-* `gtd_region` - (Optional) Shows id of GTD region in which record is to be created, 1 for World (Default), 2 for Europe, 3 for US East, 4 for US West, 5 for Asia Pacific, 6 for Oceania, note: "gtdRegion" from 2 to 6 will be applied only when GTD region is enabled on domain.
-* `type` - (Optional) Record type RP
+* `noanswer` - (Optional) Shows if record is enabled or disabled. Default is `false` (Active).
+* `note` - (Optional) Record note.
+* `gtd_region` - (Optional) Shows id of GTD region in which record is to be created. note: "gtdRegion" from 2 to 6 will be applied only when GTD region is enabled on domain. 
+  * `1` for World (Default). 
+  * `2` for Europe. 
+  * `3` for US East. 
+  * `4` for US West. 
+  * `5` for Asia Pacific. 
+  * `6` for Oceania.
+* `type` - (Optional) Record type `RP`.
 
 ## Attribute Reference ##
 This resource exports the following attributes:

--- a/website/docs/r/spf_record.html.markdown
+++ b/website/docs/r/spf_record.html.markdown
@@ -45,7 +45,8 @@ resource "constellix_spf_record" "spf1" {
 * `roundrobin.disable_flag` - (Optional) enable or disable the roundrobin object. Default is false. Atleast one roundrobin object should be false.
 
 ## Attributes Reference
-The only attribute that this resource exports is the `id`, which is set to the constellix calculated id of the SPF resource.
+This resource exports the following attributes:
+* `id` - The constellix calculated id of the SPF resource.
 
 ## Importing ##
 

--- a/website/docs/r/spf_record.html.markdown
+++ b/website/docs/r/spf_record.html.markdown
@@ -32,17 +32,23 @@ resource "constellix_spf_record" "spf1" {
 ```
 
 ## Argument Reference ##
-* `domain_id` - (Required) Record id of SPF record
-* `source_type` - (Required) Type of the PTR record. The values which can be applied are "domains" or "templates".
+* `domain_id` - (Required) Record id of SPF record.
+* `source_type` - (Required) Type of the PTR record. The values which can be applied are `domains` or `templates`.
 * `name` - (Optional) Name of record. Name should be unique.
-* `ttl` - (Required) TTL must be in between 0 and 2147483647.
-* `noanswer` - (Optional) Shows if record is enabled or disabled. Default is false (Active).
-* `note` - (Optional)Record note.
-* `gtd_region` - (Optional) Shows id of GTD region in which record is to be created. 1 for World (Default). 2 for Europe. 3 for US East. 4 for US West. 5 for Asia Pacific. 6 for Oceania. note: "gtdRegion" from 2 to 6 will be applied only when GTD region is enabled on domain.
-* `type` - (Optional) Record type A.
+* `ttl` - (Required) TTL must be in between `0` and `2147483647`.
+* `noanswer` - (Optional) Shows if record is enabled or disabled. Default is `false` (Active).
+* `note` - (Optional) Record note.
+* `gtd_region` - (Optional) Shows id of GTD region in which record is to be created. note: "gtdRegion" from 2 to 6 will be applied only when GTD region is enabled on domain. 
+  * `1` for World (Default). 
+  * `2` for Europe. 
+  * `3` for US East. 
+  * `4` for US West. 
+  * `5` for Asia Pacific. 
+  * `6` for Oceania.
+* `type` - (Optional) Record type `SPF`.
 * `roundrobin` - (Required) Object.
 * `roundrobin.value` - (Required) Value may contain multiple strings (each string enclosed in double quotes). Individual string length should not exceed 255 characters.
-* `roundrobin.disable_flag` - (Optional) enable or disable the roundrobin object. Default is false. Atleast one roundrobin object should be false.
+* `roundrobin.disable_flag` - (Optional) enable or disable the roundrobin object. Default is `false`. At least one roundrobin object should be false.
 
 ## Attributes Reference
 This resource exports the following attributes:

--- a/website/docs/r/srv_record.html.markdown
+++ b/website/docs/r/srv_record.html.markdown
@@ -49,7 +49,8 @@ resource "constellix_srv_record" "srvrecord1" {
 * `type` - (Optional) Record type SRV
 
 ## Attribute Reference ##
-The only attribute that this resource exports is the `id`, which is set to the constellix calculated id of srv resource.
+This resource exports the following attributes:
+* `id` - The constellix calculated id of srv resource.
 
 ## Importing ##
 

--- a/website/docs/r/srv_record.html.markdown
+++ b/website/docs/r/srv_record.html.markdown
@@ -34,19 +34,25 @@ resource "constellix_srv_record" "srvrecord1" {
 
 ## Argument Reference ##
 * `domain_id` - (Required) Record id of SRV record
-* `ttl` - (Required) TTL must be in between 0 and 2147483647
-* `source_type` - (Required) "domains" for Domain records and "template" for Template records
+* `ttl` - (Required) TTL must be in between `0` and `2147483647`
+* `source_type` - (Required) `domains` for Domain records and `template` for Template records
 * `roundrobin` - (Required) Set
 * `roundrobin.value` - (Required) The system that will receive the service.
-* `roundrobin.disable_flag` - (Optional) Enable or Disable the roundrobin object. Default is false. Atleast one roundrobin object should be false.
+* `roundrobin.disable_flag` - (Optional) Enable or Disable the roundrobin object. Default is false. At least one roundrobin object should be false.
 * `roundrobin.port` - (Required) The port of the service offered. Value should be between 0 and 65535.
 * `roundrobin.priority` - (Required) The lower the number in the priority field, the higher the preference of the associated target. 0 is the highest priority (lowest number). Value should be between 0 and 65535.
 * `roundrobin.weight` - (Required) The weight of the record allows an administrator to distribute load to multiple targets (load balance). Value should be between 0 and 65535.
 * `name` - (Optional) Name of record. Name should be unique.
 * `noanswer` - (Optional) Shows if record is enabled or disabled. Default is false (Active)
 * `note` - (Optional) Record note
-* `gtd_region` - (Optional) Shows id of GTD region in which record is to be created, 1 for World (Default), 2 for Europe, 3 for US East, 4 for US West, 5 for Asia Pacific, 6 for Oceania, note: "gtdRegion" from 2 to 6 will be applied only when GTD region is enabled on domain.
-* `type` - (Optional) Record type SRV
+* `gtd_region` - (Optional) Shows id of GTD region in which record is to be created. note: "gtdRegion" from 2 to 6 will be applied only when GTD region is enabled on domain. 
+  * `1` for World (Default). 
+  * `2` for Europe. 
+  * `3` for US East. 
+  * `4` for US West. 
+  * `5` for Asia Pacific. 
+  * `6` for Oceania.
+* `type` - (Optional) Record type `SRV`.
 
 ## Attribute Reference ##
 This resource exports the following attributes:

--- a/website/docs/r/tags.html.markdown
+++ b/website/docs/r/tags.html.markdown
@@ -22,8 +22,8 @@ resource "constellix_tags" "tags1" {
 
 
 ## Attribute Reference ##
-No attributes are exported
-
+This resource exports the following attributes:
+* `id` - The constellix calculated id of tag resource.
 ## Importing ##
 
 An existing Tag can be [imported][docs-import] into this resource using its Id, via the following command:

--- a/website/docs/r/tcp_check.html.markdown
+++ b/website/docs/r/tcp_check.html.markdown
@@ -23,7 +23,7 @@ resource "constellix_tcp_check" "first" {
 ```
 
 ## Argument Reference ##
-* `name` - (Required) name of the resource. Name should be unique.
+* `name` - (Required) Name of the resource. Name should be unique.
 * `host` - (Required) Host for the resource, for example "constellix.com". It can be set only once.
 * `ip_version` - (Required) Specifies the version of IP. It can be set only once.
 * `port` - (Required) Specifies the port number.

--- a/website/docs/r/tcp_check.html.markdown
+++ b/website/docs/r/tcp_check.html.markdown
@@ -36,7 +36,8 @@ resource "constellix_tcp_check" "first" {
 * `string_to_receive` - (Optional) String which should be received as a result of TCP check.
 
 ## Attribute Reference ##
-The only attribute that this resource exports is the `id`, which is set to the constellix calculated id of TCP check resource.
+This resource exports the following attributes:
+* `id` - The constellix calculated id of TCP check resource.
 
 ## Importing ##
 

--- a/website/docs/r/template.html.markdown
+++ b/website/docs/r/template.html.markdown
@@ -30,7 +30,8 @@ resource "constellix_template" "firsttemplate" {
 * `version` - (Optional) System generated template history version.
 
 ## Attributes Reference
-No attributes are exported.
+This resource exports the following attributes:
+* `id` - The constellix calculated id of the template resource.
 
 ## Importing ##
 

--- a/website/docs/r/txt_record.html.markdown
+++ b/website/docs/r/txt_record.html.markdown
@@ -29,17 +29,23 @@ resource "constellix_txt_record" "txtrecord1" {
 ```
 
 ## Argument Reference ##
-* `domain_id` - (Required) Record id of TXT record
-* `ttl` - (Required) TTL must be in between 0 and 2147483647
-* `source_type` - (Required) "domains" for Domain records and "template" for Template records
-* `roundrobin` - (Required) Set
-* `roundrobin.value` - (Required) Free form text data of any type which may be no longer than 255 characters unless divided into multiple strings with sets of quotation marks..
-* `roundrobin.disable_flag` - (Optional) Disable flag. Default is false
+* `domain_id` - (Required) Record id of TXT record.
+* `ttl` - (Required) TTL must be in between `0` and `2147483647`.
+* `source_type` - (Required) `domains` for Domain records and `template` for Template records.
+* `roundrobin` - (Required) Set.
+* `roundrobin.value` - (Required) Free form text data of any type which may be no longer than 255 characters unless divided into multiple strings with sets of quotation marks.
+* `roundrobin.disable_flag` - (Optional) Disable flag. Default is false.
 * `name` - (Optional) Name of record. Name should be unique.
-* `noanswer` - (Optional) Shows if record is enabled or disabled. Default is false (Active)
-* `note` - (Optional) Record note
-* `gtd_region` - (Optional) Shows id of GTD region in which record is to be created, 1 for World (Default), 2 for Europe, 3 for US East, 4 for US West, 5 for Asia Pacific, 6 for Oceania, note: "gtdRegion" from 2 to 6 will be applied only when GTD region is enabled on domain.
-* `type` - (Optional) Record type TXT
+* `noanswer` - (Optional) Shows if record is enabled or disabled. Default is false (Active).
+* `note` - (Optional) Record note.
+* `gtd_region` - (Optional) Shows id of GTD region in which record is to be created. note: "gtdRegion" from 2 to 6 will be applied only when GTD region is enabled on domain. 
+  * `1` for World (Default). 
+  * `2` for Europe. 
+  * `3` for US East. 
+  * `4` for US West. 
+  * `5` for Asia Pacific. 
+  * `6` for Oceania.
+* `type` - (Optional) Record type `TXT`.
 
 ## Attribute Reference ##
 This resource exports the following attributes:

--- a/website/docs/r/txt_record.html.markdown
+++ b/website/docs/r/txt_record.html.markdown
@@ -42,7 +42,8 @@ resource "constellix_txt_record" "txtrecord1" {
 * `type` - (Optional) Record type TXT
 
 ## Attribute Reference ##
-The only attribute that this resource exports is the `id`, which is set to the constellix calculated id of txt resource.
+This resource exports the following attributes:
+* `id` - The constellix calculated id of txt resource.
 
 ## Importing ##
 

--- a/website/docs/r/vanity_nameserver.html.markdown
+++ b/website/docs/r/vanity_nameserver.html.markdown
@@ -25,11 +25,11 @@ resource "constellix_vanity_nameserver" "vanitynameserver1" {
 
 ## Argument Reference ##
 * `name` - (Required) Vanity nameserver name should be unique.
-* `nameserver_group` - (Required) Name server group id. 1 .. Available nameserver groups
+* `nameserver_group` - (Required) Name server group id. Available nameserver groups: `1`.
 * `nameserver_list_string` - (Required) Comma separated name servers list
 * `is_default` - (Optional) Default flag. Default is false.
 * `is_public` - (Optional) isPublic flag. Default is false
-* `nameserver_group_name` - (Optional) Name server group name
+* `nameserver_group_name` - (Optional) Name server group name.
 
 ## Attribute Reference ##
 This resource exports the following attributes:

--- a/website/docs/r/vanity_nameserver.html.markdown
+++ b/website/docs/r/vanity_nameserver.html.markdown
@@ -32,7 +32,8 @@ resource "constellix_vanity_nameserver" "vanitynameserver1" {
 * `nameserver_group_name` - (Optional) Name server group name
 
 ## Attribute Reference ##
-The only attribute that this resource exports is the `id`, which is set to the constellix calculated id of vanitynameserver resource.
+This resource exports the following attributes:
+* `id` - The constellix calculated id of vanitynameserver resource.
 
 ## Importing ##
 


### PR DESCRIPTION
Making Changes to the terraform documentation to allow for easier readability. Also some updates to the "Attributes Reference" for some of the resources that didn't list that they returned IDs though upon inspection of the code, they do in fact return ids.