### PR TITLE
fix-domain-creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .vscode
 **/.terraform
 **/.tfstate
+
+.idea
+tests

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -12,7 +12,7 @@ build: fmtcheck
 test: fmtcheck
 	go test -i $(TEST) || exit 1
 	echo $(TEST) | \
-		xargs -t -n4 go test $(TESTARGS) -timeout=30s -parallel=4
+		xargs -t -n4 go test -v $(TESTARGS) -timeout=30s -parallel=4
 
 testacc: fmtcheck
 	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 120m

--- a/constellix/datasource_constellix_domain.go
+++ b/constellix/datasource_constellix_domain.go
@@ -23,6 +23,12 @@ func datasourceConstellixDomain() *schema.Resource {
 				ForceNew: true,
 			},
 
+			"disabled": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+
 			"has_gtd_regions": &schema.Schema{
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -160,6 +166,9 @@ func datasourceConstellixDomainRead(d *schema.ResourceData, m interface{}) error
 			d.SetId(stripQuotes(obj.Index(i).S("id").String()))
 			d.Set("name", stripQuotes(obj.Index(i).S("name").String()))
 			d.Set("soa", soaset)
+			if disabled, err := strconv.ParseBool(stripQuotes(obj.Index(i).S("disabled").String())); err == nil {
+				d.Set("disabled", disabled)
+			}
 			if hasGeoIP, err := strconv.ParseBool(stripQuotes(obj.Index(i).S("hasGeoIP").String())); err == nil {
 				d.Set("has_geoip", hasGeoIP)
 			}

--- a/constellix/model.go
+++ b/constellix/model.go
@@ -1,0 +1,16 @@
+package constellix
+
+import (
+	"github.com/Constellix/constellix-go-client/models"
+)
+
+// DomainAttributes extends the models.DomainAttributes.
+type DomainAttributes struct {
+	models.DomainAttributes
+	Disabled bool `json:"disabled"`
+}
+
+// DomainAttributesV4 contains the domain attributes aligned with API v4.
+type DomainAttributesV4 struct {
+	Enabled bool `json:"enabled"`
+}

--- a/constellix/resource_constellix_domain.go
+++ b/constellix/resource_constellix_domain.go
@@ -146,7 +146,7 @@ func resourceConstellixDNSImport(d *schema.ResourceData, m interface{}) ([]*sche
 	constellixClient := m.(*client.Client)
 	resp, err := constellixClient.GetbyId("v1/domains/" + d.Id())
 	if err != nil {
-		if resp.StatusCode == 404 {
+		if resp != nil && resp.StatusCode == 404 {
 			d.SetId("")
 			return nil, err
 		}
@@ -163,16 +163,10 @@ func resourceConstellixDNSImport(d *schema.ResourceData, m interface{}) ([]*sche
 	}
 
 	soaset := make(map[string]interface{})
-	if value, ok := d.GetOk("soa"); ok {
-		tp := value.(map[string]interface{})
-		if tp["email"] != nil {
-			soaset["email"] = stripQuotes(obj.S("soa", "email").String())
-		}
-	}
-
 	if obj.Exists("soa") {
-		soaset["primary_nameserver"] = stripQuotes(obj.S("soa", "primaryNameserver").String())
 		soaset["ttl"] = stripQuotes(obj.S("soa", "ttl").String())
+		soaset["primary_nameserver"] = stripQuotes(obj.S("soa", "primaryNameserver").String())
+		soaset["email"] = stripQuotes(obj.S("soa", "email").String())
 		soaset["refresh"] = stripQuotes(obj.S("soa", "refresh").String())
 		soaset["expire"] = stripQuotes(obj.S("soa", "expire").String())
 		soaset["retry"] = stripQuotes(obj.S("soa", "retry").String())
@@ -366,14 +360,9 @@ func resourceConstellixDNSRead(d *schema.ResourceData, m interface{}) error {
 	}
 
 	soaset := make(map[string]interface{})
-	if value, ok := d.GetOk("soa"); ok {
-		tp := value.(map[string]interface{})
-		if tp["email"] != nil {
-			soaset["email"] = stripQuotes(obj.S("soa", "email").String())
-		}
-	}
 	if obj.Exists("soa") {
 		soaset["primary_nameserver"] = stripQuotes(obj.S("soa", "primaryNameserver").String())
+		soaset["email"] = stripQuotes(obj.S("soa", "email").String())
 		soaset["ttl"] = stripQuotes(obj.S("soa", "ttl").String())
 		soaset["refresh"] = stripQuotes(obj.S("soa", "refresh").String())
 		soaset["expire"] = stripQuotes(obj.S("soa", "expire").String())

--- a/constellix/resource_constellix_domain.go
+++ b/constellix/resource_constellix_domain.go
@@ -3,7 +3,7 @@ package constellix
 import (
 	"encoding/json"
 	"fmt"
-	"io"
+	"io/ioutil"
 	"log"
 	"strconv"
 	"strings"
@@ -152,7 +152,7 @@ func resourceConstellixDNSImport(d *schema.ResourceData, m interface{}) ([]*sche
 		}
 		return nil, err
 	}
-	bodyBytes, err := io.ReadAll(resp.Body)
+	bodyBytes, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -303,7 +303,7 @@ func resourceConstellixDNSCreate(d *schema.ResourceData, m interface{}) error {
 			}
 		}
 	} else {
-		bodyBytes, err := io.ReadAll(resp.Body)
+		bodyBytes, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
 			return err
 		}
@@ -349,7 +349,7 @@ func resourceConstellixDNSRead(d *schema.ResourceData, m interface{}) error {
 		}
 		return err
 	}
-	bodyBytes, err := io.ReadAll(resp.Body)
+	bodyBytes, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}

--- a/constellix/resource_constellix_domain_test.go
+++ b/constellix/resource_constellix_domain_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"net/http"
 	"regexp"
 	"testing"
@@ -29,6 +30,9 @@ func TestAccConstellixDomainCreation(t *testing.T) {
 		CheckDestroy: testAccCheckConstellixDomainDestroy,
 		Steps: []resource.TestStep{
 			{
+				PreConfig: func() {
+					log.Println("should successfully create a domain with note and disabled (set to false) attributes")
+				},
 				Config: testAccCheckConstellixDomainConfig(
 					testName1,
 					domainName1,
@@ -47,6 +51,9 @@ func TestAccConstellixDomainCreation(t *testing.T) {
 				),
 			},
 			{
+				PreConfig: func() {
+					log.Println("should successfully create a domain with note and disabled (set to true) attributes")
+				},
 				Config: testAccCheckConstellixDomainConfig(
 					testName2,
 					domainName2,
@@ -78,6 +85,9 @@ func TestAccConstellixDomainCreationFailure(t *testing.T) {
 		CheckDestroy: testAccCheckConstellixDomainDestroy,
 		Steps: []resource.TestStep{
 			{
+				PreConfig: func() {
+					log.Println("should error when attempt to create a domain with an invalid name")
+				},
 				Config: testAccCheckConstellixDomainConfig(
 					testName,
 					invalidDomainName,
@@ -123,6 +133,9 @@ func TestAccConstellixDomainUpdate(t *testing.T) {
 		CheckDestroy: testAccCheckConstellixDomainDestroy,
 		Steps: []resource.TestStep{
 			{
+				PreConfig: func() {
+					log.Println("should create a domain for follow up steps testing update operation on a domain")
+				},
 				Config: initialConfig,
 				Check: resource.ComposeTestCheckFunc(
 					// Load domain from API.
@@ -136,6 +149,9 @@ func TestAccConstellixDomainUpdate(t *testing.T) {
 				),
 			},
 			{
+				PreConfig: func() {
+					log.Println("should update values of note and disabled attributes (set to true) of a domain")
+				},
 				Config: updatedConfig1,
 				Check: resource.ComposeTestCheckFunc(
 					// Load domain from API.
@@ -149,6 +165,9 @@ func TestAccConstellixDomainUpdate(t *testing.T) {
 				),
 			},
 			{
+				PreConfig: func() {
+					log.Println("should update values of note and disabled attributes (set to false) of a domain")
+				},
 				Config: updatedConfig2,
 				Check: resource.ComposeTestCheckFunc(
 					// Load domain from API.
@@ -177,6 +196,9 @@ func TestAccConstellixDomainImport(t *testing.T) {
 		CheckDestroy: testAccCheckConstellixDomainDestroy,
 		Steps: []resource.TestStep{
 			{
+				PreConfig: func() {
+					log.Println("should create a domain for follow up steps testing import operation on domain")
+				},
 				Config: testAccCheckConstellixDomainConfig(
 					testName,
 					domainName,
@@ -195,6 +217,9 @@ func TestAccConstellixDomainImport(t *testing.T) {
 				),
 			},
 			{
+				PreConfig: func() {
+					log.Println("should validate import state of a domain")
+				},
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,

--- a/constellix/resource_constellix_domain_test.go
+++ b/constellix/resource_constellix_domain_test.go
@@ -3,7 +3,7 @@ package constellix
 import (
 	"encoding/json"
 	"fmt"
-	"io"
+	"io/ioutil"
 	"net/http"
 	"testing"
 
@@ -223,7 +223,7 @@ func testAccCheckConstellixDomainExists(domain *DomainAttributes, resourceName s
 }
 
 func domainFromResponse(resp *http.Response) (*DomainAttributes, error) {
-	bodyBytes, err := io.ReadAll(resp.Body)
+	bodyBytes, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/website/docs/d/domain.html.markdown
+++ b/website/docs/d/domain.html.markdown
@@ -23,6 +23,7 @@ data "constellix_domain" "domain1" {
 
 ## Attribute Reference
 
+* `disabled` - (Optional) Indicates if the domain is disabled. The Default value is false.
 * `has_gtd_regions` - (Optional) GTD Region status of the domain. The Default value is false.
 * `has_geoip` - (Optional) GTD Region status of the domain. The Default value is false.
 * `vanity_nameserver` - (Optional) vanity nameserver of domain.

--- a/website/docs/r/domain.html.markdown
+++ b/website/docs/r/domain.html.markdown
@@ -14,6 +14,7 @@ resource "constellix_domain" "domain1" {
   name = "domain1.com"
   soa = {
     primary_nameserver = "ns41.constellix.com."
+    email              = "dns.constellix.com."
     ttl                = 1800
     refresh            = 48100
     retry              = 7200

--- a/website/docs/r/domain.html.markdown
+++ b/website/docs/r/domain.html.markdown
@@ -27,6 +27,7 @@ resource "constellix_domain" "domain1" {
 ## Argument Reference ##
 
 * `name` - (Required) Name of the domain.
+* `disabled` - (Optional) Indicates if the domain is disabled. The Default value is `false`.
 * `has_gtd_regions` - (Optional) GTD Region status of the domain. The Default value is `false`.
 * `has_geoip` - (Optional) GTD Region status of the domain. The Default value is `false`.
 * `vanity_nameserver` - (Optional) vanity nameserver of domain.


### PR DESCRIPTION
- **refactor: Update gitignore.**
- **fix: If domain already exists, load and respond with domain object.**
- **feat: Allow `disabled` attribute to be set during create and updated operations on `constellix_domain`.**
- **fix: Populate `soa.email` field when doing terraform import.**
- **fix: Add test to ensure terraform state is correctly created with terraform import operation.**
- **refactor: Keep using `ioutil.ReadAll` as version bump requires a lot of work.**
- **doc: Update documentation of `domain` to include attribute "disabled".**
- **doc: Add option `soa.email` attribute in the example usage.**
- **fix: Add missing `-v` flag when testing.**
- **test: Add failing path test for domain creation.**
- **test: Add description for each test step.**
- **test: Add test to validate idempotent creation of domains.**
- **test: Add test to validate import an existing domain via create operation.**